### PR TITLE
Load Ad in browser if handledByMraidBrowser fails

### DIFF
--- a/mopub-sdk/src/main/java/com/mopub/mobileads/HtmlWebViewClient.java
+++ b/mopub-sdk/src/main/java/com/mopub/mobileads/HtmlWebViewClient.java
@@ -204,7 +204,7 @@ class HtmlWebViewClient extends WebViewClient {
         boolean handledByMraidBrowser = launchIntentForUserClick(mContext, intent, errorMessage);
 
         if (!handledByMraidBrowser) {
-            intent = new Intent(Intent.ACTION_VIEW, Uri.parse("about:blank"));
+            intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
             intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             launchIntentForUserClick(mContext, intent, null);
         }


### PR DESCRIPTION
If the user wishes to show the Ad in the native browser all he has to do is, to not include the MraidBrowser activity deceleration in manifest.