### PR TITLE
Added Javascript interface for the webview to enable deep-link support

### DIFF
--- a/mopub-sdk/src/main/java/com/mopub/mobileads/BaseHtmlWebView.java
+++ b/mopub-sdk/src/main/java/com/mopub/mobileads/BaseHtmlWebView.java
@@ -30,6 +30,28 @@ public class BaseHtmlWebView extends BaseWebView implements UserClickListener {
             enablePlugins(true);
         }
         setBackgroundColor(Color.TRANSPARENT);
+
+        // Setup Javascript interface for webview
+        setupJSInterface(this);
+    }
+
+    private void setupJSInterface(WebView webView) {
+        JSInterface jsInterface = new JSInterface();
+        webView.getSettings().setJavaScriptEnabled(true);
+        webView.addJavascriptInterface(jsInterface, "JSInterface");
+    }
+
+    /**
+     * Interface for methods that can be invoked from Javascript
+     */
+    public class JSInterface {
+        /**
+         * Check if the intent can be handled by the device
+         */
+        @JavascriptInterface
+        public boolean canHandleIntentUrl(String intent){
+            return Intents.canHandleApplicationUrl(getContext(), intent);
+        }
     }
 
     public void init(boolean isScrollable) {


### PR DESCRIPTION
Currently for the Web Ads rendered inside MoPubView, there is no mechanism to supply both Deep-link Intent Url and Fallback Web Url
- When ads in webview are clicked, and if the deep-link intent fails to resolve, there is no fallback Url support
- Exposed a method to javascript, which can determine if the intent is resolvable by Android system.
- If intent cannot be handled by the device, JS code can launch web_link instead.

Sample JS Usage:
```
		if (window.JSInterface.canHandleIntentUrl(nativeIntentUrl)) {
		  clickUrl = nativeIntentUrl;
		} else {
		  clickUrl = webUrl;
		}
		window.location.replace(clickUrl);
```