### PR TITLE
Use a shared singleton for ChartboostInterstitial and ChartboostRewarded.

### DIFF
--- a/extras/src/com/mopub/mobileads/ChartboostInterstitial.java
+++ b/extras/src/com/mopub/mobileads/ChartboostInterstitial.java
@@ -5,13 +5,9 @@ import android.content.Context;
 import android.util.Log;
 
 import com.chartboost.sdk.Chartboost;
-import com.chartboost.sdk.ChartboostDelegate;
 import com.mopub.common.VisibleForTesting;
 
-import java.util.HashMap;
 import java.util.Map;
-
-import static com.chartboost.sdk.Model.CBError.CBImpressionError;
 
 /*
  * Tested with Chartboost SDK 5.0.4.
@@ -65,20 +61,16 @@ class ChartboostInterstitial extends CustomEventInterstitial {
             return;
         }
 
-        Activity activity = (Activity) context;
-        Chartboost.startWithAppId(activity, appId, appSignature);
-
-        if (getDelegate().hasLocation(location) &&
-                getDelegate().getListener(location) != interstitialListener) {
-            interstitialListener.onInterstitialFailed(MoPubErrorCode.ADAPTER_CONFIGURATION_ERROR);
-            return;
-        }
-
+        // Set the listener.
         getDelegate().registerListener(location, interstitialListener);
+
+        // Start Chartboost and get an ad.
+        Activity activity = (Activity) context;
+
+        Chartboost.startWithAppId(activity, appId, appSignature);
+        Chartboost.setImpressionsUseActivities(false);
         Chartboost.setDelegate(getDelegate());
-        Chartboost.setAutoCacheAds(false);
         Chartboost.setShouldRequestInterstitialsInFirstSession(true);
-        Chartboost.setShouldDisplayLoadingViewForMoreApps(false);
         Chartboost.onCreate(activity);
         Chartboost.onStart(activity);
         Chartboost.cacheInterstitial(location);
@@ -112,120 +104,8 @@ class ChartboostInterstitial extends CustomEventInterstitial {
     }
 
     @VisibleForTesting
-    static class SingletonChartboostDelegate extends ChartboostDelegate {
-        private static final CustomEventInterstitialListener NULL_LISTENER = new CustomEventInterstitialListener() {
-            @Override public void onInterstitialLoaded() { }
-            @Override public void onInterstitialFailed(MoPubErrorCode errorCode) { }
-            @Override public void onInterstitialShown() { }
-            @Override public void onInterstitialClicked() { }
-            @Override public void onLeaveApplication() { }
-            @Override public void onInterstitialDismissed() { }
-        };
-        static SingletonChartboostDelegate instance = new SingletonChartboostDelegate();
-        private Map<String, CustomEventInterstitialListener> listenerForLocation =
-                new HashMap<String, CustomEventInterstitialListener>();
-
-        public void registerListener(String location, CustomEventInterstitialListener interstitialListener) {
-            listenerForLocation.put(location, interstitialListener);
-        }
-
-        public void unregisterListener(String location) {
-            listenerForLocation.remove(location);
-        }
-
-        public boolean hasLocation(String location) {
-            return listenerForLocation.containsKey(location);
-        }
-
-        /*
-         * Interstitial delegate methods
-         */
-        @Override
-        public boolean shouldDisplayInterstitial(String location) {
-            return true;
-        }
-
-        @Override
-        public boolean shouldRequestInterstitial(String location) {
-            return true;
-        }
-
-        @Override
-        public void didCacheInterstitial(String location) {
-            Log.d("MoPub", "Chartboost interstitial loaded successfully.");
-            getListener(location).onInterstitialLoaded();
-        }
-
-        @Override
-        public void didFailToLoadInterstitial(String location, CBImpressionError error) {
-            Log.d("MoPub", "Chartboost interstitial ad failed to load. Error: " + error.name());
-            getListener(location).onInterstitialFailed(MoPubErrorCode.NETWORK_NO_FILL);
-        }
-
-        @Override
-        public void didDismissInterstitial(String location) {
-            // Note that this method is fired before didCloseInterstitial and didClickInterstitial.
-            Log.d("MoPub", "Chartboost interstitial ad dismissed.");
-            getListener(location).onInterstitialDismissed();
-        }
-
-        @Override
-        public void didCloseInterstitial(String location) {
-        }
-
-        @Override
-        public void didClickInterstitial(String location) {
-            Log.d("MoPub", "Chartboost interstitial ad clicked.");
-            getListener(location).onInterstitialClicked();
-        }
-
-        @Override
-        public void didDisplayInterstitial(String location) {
-            Log.d("MoPub", "Chartboost interstitial ad shown.");
-            getListener(location).onInterstitialShown();
-        }
-
-        /*
-         * More Apps delegate methods
-         */
-        @Override
-        public boolean shouldRequestMoreApps(String location) {
-            return false;
-        }
-
-        @Override
-        public boolean shouldDisplayMoreApps(String location) {
-            return false;
-        }
-
-        @Override
-        public void didFailToLoadMoreApps(String location, CBImpressionError error) {
-        }
-
-        @Override
-        public void didCacheMoreApps(String location) {
-        }
-
-        @Override
-        public void didDismissMoreApps(String location) {
-        }
-
-        @Override
-        public void didCloseMoreApps(String location) {
-        }
-
-        @Override
-        public void didClickMoreApps(String location) {
-        }
-
-        CustomEventInterstitialListener getListener(String location) {
-            CustomEventInterstitialListener listener = listenerForLocation.get(location);
-            return listener != null ? listener : NULL_LISTENER;
-        }
-    }
-
-    @VisibleForTesting
     @Deprecated
+    @SuppressWarnings("unused")
     public static void resetDelegate() {
         SingletonChartboostDelegate.instance = new SingletonChartboostDelegate();
     }

--- a/extras/src/com/mopub/mobileads/ChartboostInterstitial.java
+++ b/extras/src/com/mopub/mobileads/ChartboostInterstitial.java
@@ -68,6 +68,7 @@ class ChartboostInterstitial extends CustomEventInterstitial {
         Activity activity = (Activity) context;
 
         Chartboost.startWithAppId(activity, appId, appSignature);
+        Chartboost.setFramework(Chartboost.CBFramework.CBFrameworkMoPub);
         Chartboost.setImpressionsUseActivities(false);
         Chartboost.setDelegate(getDelegate());
         Chartboost.setShouldRequestInterstitialsInFirstSession(true);

--- a/extras/src/com/mopub/mobileads/ChartboostRewardedVideo.java
+++ b/extras/src/com/mopub/mobileads/ChartboostRewardedVideo.java
@@ -3,19 +3,15 @@ package com.mopub.mobileads;
 import android.app.Activity;
 import android.os.Handler;
 import android.support.annotation.NonNull;
+
 import com.chartboost.sdk.Chartboost;
-import com.chartboost.sdk.ChartboostDelegate;
-import com.chartboost.sdk.Model.CBError;
 import com.mopub.common.DataKeys;
 import com.mopub.common.LifecycleListener;
 import com.mopub.common.MediationSettings;
-import com.mopub.common.MoPubReward;
 import com.mopub.common.VisibleForTesting;
 import com.mopub.common.logging.MoPubLog;
 
 import java.util.*;
-
-import static com.mopub.mobileads.MoPubErrorCode.VIDEO_DOWNLOAD_ERROR;
 
 /**
  * A custom event for showing Chartboost rewarded videos.
@@ -28,8 +24,6 @@ public class ChartboostRewardedVideo extends CustomEventRewardedVideo {
     public static final String LOCATION_KEY = "location";
     public static final String LOCATION_DEFAULT = "Default";
 
-    @NonNull private static final SingletonChartboostDelegate sSingletonChartboostDelegate =
-            new SingletonChartboostDelegate();
     @NonNull private static final LifecycleListener sLifecycleListener =
             new ChartboostLifecycleListener();
     private static boolean sInitialized = false;
@@ -44,7 +38,7 @@ public class ChartboostRewardedVideo extends CustomEventRewardedVideo {
     @Override
     @NonNull
     public CustomEventRewardedVideoListener getVideoListenerForSdk() {
-        return sSingletonChartboostDelegate;
+        return SingletonChartboostDelegate.instance;
     }
 
     @Override
@@ -82,7 +76,11 @@ public class ChartboostRewardedVideo extends CustomEventRewardedVideo {
             final String appSignature = serverExtras.get(APP_SIGNATURE_KEY);
 
             Chartboost.startWithAppId(launcherActivity, appId, appSignature);
-            Chartboost.setDelegate(sSingletonChartboostDelegate);
+            Chartboost.setImpressionsUseActivities(false);
+            Chartboost.setDelegate((SingletonChartboostDelegate) getVideoListenerForSdk());
+            Chartboost.setShouldRequestInterstitialsInFirstSession(true);
+            Chartboost.onCreate(launcherActivity);
+            Chartboost.onStart(launcherActivity);
 
             sInitialized = true;
             return true;
@@ -99,7 +97,7 @@ public class ChartboostRewardedVideo extends CustomEventRewardedVideo {
             mLocation = LOCATION_DEFAULT;
         }
 
-        sSingletonChartboostDelegate.mLocationsToLoad.add(mLocation);
+        ((SingletonChartboostDelegate) getVideoListenerForSdk()).getRewardedLocationsToLoad().add(mLocation);
         setUpMediationSettingsForRequest((String) localExtras.get(DataKeys.AD_UNIT_ID_KEY));
 
         // We do this to ensure that the custom event manager has a chance to get the listener
@@ -142,79 +140,7 @@ public class ChartboostRewardedVideo extends CustomEventRewardedVideo {
     @Override
     protected void onInvalidate() {
         // This prevents sending didCache or didFailToCache callbacks.
-        sSingletonChartboostDelegate.mLocationsToLoad.remove(mLocation);
-    }
-
-    private static final class SingletonChartboostDelegate extends ChartboostDelegate
-            implements CustomEventRewardedVideoListener {
-
-        private Set<String> mLocationsToLoad = Collections.synchronizedSet(new TreeSet<String>());
-
-        @Override
-        public boolean shouldDisplayRewardedVideo(String location) {
-            return super.shouldDisplayRewardedVideo(location);
-        }
-
-        @Override
-        public void didCacheRewardedVideo(String location) {
-            super.didCacheRewardedVideo(location);
-
-            if (mLocationsToLoad.contains(location)) {
-                MoPubLog.d("Chartboost rewarded video cached for location " + location + ".");
-                MoPubRewardedVideoManager.onRewardedVideoLoadSuccess(ChartboostRewardedVideo.class, location);
-                mLocationsToLoad.remove(location);
-            }
-        }
-
-        @Override
-        public void didFailToLoadRewardedVideo(String location, CBError.CBImpressionError error) {
-            super.didFailToLoadRewardedVideo(location, error);
-
-            if (mLocationsToLoad.contains(location)) {
-                MoPubLog.d("Chartboost rewarded video cache failed for location " + location + ".");
-                MoPubRewardedVideoManager.onRewardedVideoLoadFailure(ChartboostRewardedVideo.class, location, VIDEO_DOWNLOAD_ERROR);
-                mLocationsToLoad.remove(location);
-            }
-        }
-
-        @Override
-        public void didDismissRewardedVideo(String location) {
-            // This is called before didCloseRewardedVideo and didClickRewardedVideo
-            super.didDismissRewardedVideo(location);
-            MoPubRewardedVideoManager.onRewardedVideoClosed(ChartboostRewardedVideo.class, location);
-            MoPubLog.d("Chartboost rewarded video dismissed for location " + location + ".");
-        }
-
-        @Override
-        public void didCloseRewardedVideo(String location) {
-            super.didCloseRewardedVideo(location);
-            MoPubLog.d("Chartboost rewarded video closed for location " + location + ".");
-        }
-
-        @Override
-        public void didClickRewardedVideo(String location) {
-            super.didClickRewardedVideo(location);
-            MoPubRewardedVideoManager.onRewardedVideoClicked(ChartboostRewardedVideo.class, location);
-            MoPubLog.d("Chartboost rewarded video clicked for location " + location + ".");
-        }
-
-        @Override
-        public void didCompleteRewardedVideo(String location, int reward) {
-            super.didCompleteRewardedVideo(location, reward);
-            MoPubLog.d("Chartboost rewarded video completed for location " + location + " with "
-                    + "reward amount " + reward);
-            MoPubRewardedVideoManager.onRewardedVideoCompleted(
-                    ChartboostRewardedVideo.class,
-                    location,
-                    MoPubReward.success(MoPubReward.NO_REWARD_LABEL, reward));
-        }
-
-        @Override
-        public void didDisplayRewardedVideo(String location) {
-            super.didDisplayRewardedVideo(location);
-            MoPubLog.d("Chartboost rewarded video displayed for location " + location + ".");
-            MoPubRewardedVideoManager.onRewardedVideoStarted(ChartboostRewardedVideo.class, location);
-        }
+        ((SingletonChartboostDelegate)getVideoListenerForSdk()).getRewardedLocationsToLoad().remove(mLocation);
     }
 
     private static final class ChartboostLifecycleListener implements LifecycleListener {
@@ -272,6 +198,7 @@ public class ChartboostRewardedVideo extends CustomEventRewardedVideo {
 
     @Deprecated // for testing
     @VisibleForTesting
+    @SuppressWarnings("unused")
     static void resetInitialization() {
         sInitialized = false;
     }

--- a/extras/src/com/mopub/mobileads/ChartboostRewardedVideo.java
+++ b/extras/src/com/mopub/mobileads/ChartboostRewardedVideo.java
@@ -76,6 +76,7 @@ public class ChartboostRewardedVideo extends CustomEventRewardedVideo {
             final String appSignature = serverExtras.get(APP_SIGNATURE_KEY);
 
             Chartboost.startWithAppId(launcherActivity, appId, appSignature);
+            Chartboost.setFramework(Chartboost.CBFramework.CBFrameworkMoPub);
             Chartboost.setImpressionsUseActivities(false);
             Chartboost.setDelegate((SingletonChartboostDelegate) getVideoListenerForSdk());
             Chartboost.setShouldRequestInterstitialsInFirstSession(true);

--- a/extras/src/com/mopub/mobileads/SingletonChartboostDelegate.java
+++ b/extras/src/com/mopub/mobileads/SingletonChartboostDelegate.java
@@ -1,0 +1,219 @@
+package com.mopub.mobileads;
+
+import android.util.Log;
+
+import com.chartboost.sdk.ChartboostDelegate;
+import com.chartboost.sdk.Model.CBError;
+import com.mopub.common.MoPubReward;
+import com.mopub.common.VisibleForTesting;
+import com.mopub.common.logging.MoPubLog;
+import com.mopub.mobileads.CustomEventRewardedVideo.CustomEventRewardedVideoListener;
+import com.mopub.mobileads.CustomEventInterstitial.CustomEventInterstitialListener;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.chartboost.sdk.Model.CBError.CBImpressionError;
+import static com.mopub.mobileads.MoPubErrorCode.VIDEO_DOWNLOAD_ERROR;
+
+@VisibleForTesting
+class SingletonChartboostDelegate extends ChartboostDelegate
+        implements CustomEventRewardedVideoListener {
+
+    private static final CustomEventInterstitialListener NULL_LISTENER = new CustomEventInterstitialListener() {
+        @Override public void onInterstitialLoaded() { }
+        @Override public void onInterstitialFailed(MoPubErrorCode errorCode) { }
+        @Override public void onInterstitialShown() { }
+        @Override public void onInterstitialClicked() { }
+        @Override public void onLeaveApplication() { }
+        @Override public void onInterstitialDismissed() { }
+    };
+
+    static SingletonChartboostDelegate instance = new SingletonChartboostDelegate();
+
+    private Map<String, CustomEventInterstitialListener> mInterstitialLocationsToLoad =
+            new HashMap<String, CustomEventInterstitialListener>();
+
+    private Set<String> mRewardedLocationsToLoad = Collections.synchronizedSet(new TreeSet<String>());
+
+    public Map<String, CustomEventInterstitialListener> getInterstitialLocationsToLoad() {
+        return mInterstitialLocationsToLoad;
+    }
+
+    public Set<String> getRewardedLocationsToLoad() {
+        return mRewardedLocationsToLoad;
+    }
+
+    public void registerListener(String location, CustomEventInterstitialListener interstitialListener) {
+        getInterstitialLocationsToLoad().put(location, interstitialListener);
+    }
+
+    public void unregisterListener(String location) {
+        getInterstitialLocationsToLoad().remove(location);
+    }
+
+    @SuppressWarnings("unused")
+    public boolean hasLocation(String location) {
+        return getInterstitialLocationsToLoad().containsKey(location);
+    }
+
+    CustomEventInterstitialListener getListener(String location) {
+        CustomEventInterstitialListener listener = getInterstitialLocationsToLoad().get(location);
+        return listener != null ? listener : NULL_LISTENER;
+    }
+
+    /*
+     * Interstitial delegate methods
+     */
+    @Override
+    public boolean shouldDisplayInterstitial(String location) {
+        return true;
+    }
+
+    @Override
+    public boolean shouldRequestInterstitial(String location) {
+        return true;
+    }
+
+    @Override
+    public void didCacheInterstitial(String location) {
+        Log.d("MoPub", "Chartboost interstitial loaded successfully.");
+        getListener(location).onInterstitialLoaded();
+    }
+
+    @Override
+    public void didFailToLoadInterstitial(String location, CBImpressionError error) {
+        Log.d("MoPub", "Chartboost interstitial ad failed to load. Error: " + error.name());
+        getListener(location).onInterstitialFailed(MoPubErrorCode.NETWORK_NO_FILL);
+    }
+
+    @Override
+    public void didDismissInterstitial(String location) {
+        // Note that this method is fired before didCloseInterstitial and didClickInterstitial.
+        Log.d("MoPub", "Chartboost interstitial ad dismissed.");
+        getListener(location).onInterstitialDismissed();
+    }
+
+    @Override
+    public void didCloseInterstitial(String location) {
+    }
+
+    @Override
+    public void didClickInterstitial(String location) {
+        Log.d("MoPub", "Chartboost interstitial ad clicked.");
+        getListener(location).onInterstitialClicked();
+    }
+
+    @Override
+    public void didDisplayInterstitial(String location) {
+        Log.d("MoPub", "Chartboost interstitial ad shown.");
+        getListener(location).onInterstitialShown();
+    }
+
+    /*
+     * More Apps delegate methods
+     */
+    @Override
+    public boolean shouldRequestMoreApps(String location) {
+        return false;
+    }
+
+    @Override
+    public boolean shouldDisplayMoreApps(String location) {
+        return false;
+    }
+
+    @Override
+    public void didFailToLoadMoreApps(String location, CBImpressionError error) {
+    }
+
+    @Override
+    public void didCacheMoreApps(String location) {
+    }
+
+    @Override
+    public void didDismissMoreApps(String location) {
+    }
+
+    @Override
+    public void didCloseMoreApps(String location) {
+    }
+
+    @Override
+    public void didClickMoreApps(String location) {
+    }
+
+
+    /*
+     * Rewarded video delegate methods
+     */
+    @Override
+    public boolean shouldDisplayRewardedVideo(String location) {
+        return super.shouldDisplayRewardedVideo(location);
+    }
+
+    @Override
+    public void didCacheRewardedVideo(String location) {
+        super.didCacheRewardedVideo(location);
+
+        if (getRewardedLocationsToLoad().contains(location)) {
+            MoPubLog.d("Chartboost rewarded video cached for location " + location + ".");
+            MoPubRewardedVideoManager.onRewardedVideoLoadSuccess(ChartboostRewardedVideo.class, location);
+            getRewardedLocationsToLoad().remove(location);
+        }
+    }
+
+    @Override
+    public void didFailToLoadRewardedVideo(String location, CBError.CBImpressionError error) {
+        super.didFailToLoadRewardedVideo(location, error);
+
+        if (getRewardedLocationsToLoad().contains(location)) {
+            MoPubLog.d("Chartboost rewarded video cache failed for location " + location + ".");
+            MoPubRewardedVideoManager.onRewardedVideoLoadFailure(ChartboostRewardedVideo.class, location, VIDEO_DOWNLOAD_ERROR);
+            getRewardedLocationsToLoad().remove(location);
+        }
+    }
+
+    @Override
+    public void didDismissRewardedVideo(String location) {
+        // This is called before didCloseRewardedVideo and didClickRewardedVideo
+        super.didDismissRewardedVideo(location);
+        MoPubRewardedVideoManager.onRewardedVideoClosed(ChartboostRewardedVideo.class, location);
+        MoPubLog.d("Chartboost rewarded video dismissed for location " + location + ".");
+    }
+
+    @Override
+    public void didCloseRewardedVideo(String location) {
+        super.didCloseRewardedVideo(location);
+        MoPubLog.d("Chartboost rewarded video closed for location " + location + ".");
+    }
+
+    @Override
+    public void didClickRewardedVideo(String location) {
+        super.didClickRewardedVideo(location);
+        MoPubRewardedVideoManager.onRewardedVideoClicked(ChartboostRewardedVideo.class, location);
+        MoPubLog.d("Chartboost rewarded video clicked for location " + location + ".");
+    }
+
+    @Override
+    public void didCompleteRewardedVideo(String location, int reward) {
+        super.didCompleteRewardedVideo(location, reward);
+        MoPubLog.d("Chartboost rewarded video completed for location " + location + " with "
+                + "reward amount " + reward);
+        MoPubRewardedVideoManager.onRewardedVideoCompleted(
+                ChartboostRewardedVideo.class,
+                location,
+                MoPubReward.success(MoPubReward.NO_REWARD_LABEL, reward));
+    }
+
+    @Override
+    public void didDisplayRewardedVideo(String location) {
+        super.didDisplayRewardedVideo(location);
+        MoPubLog.d("Chartboost rewarded video displayed for location " + location + ".");
+        MoPubRewardedVideoManager.onRewardedVideoStarted(ChartboostRewardedVideo.class, location);
+    }
+}


### PR DESCRIPTION
## Overview

Create Chartboost singleton delegate to be shared by both rewarded video and interstitial.  Fix for Chartboost listener not being removed when interstitial ad unit is removed.

Scenario:

1) Setup a Chartboost static interstitial ad unit.
2) Using the MoPub sample app via the InterstitialDetailFragment, load the ad unit.
3) Show the ad unit.
4) Close the ad unit when it appears.
5) Load the ad unit again.

On step 5 you will get an error that no ad was found due to an internal error where the CustomEventInterstitialListener has changed for the given location.

Scenario:

Developer wants to use both ChartboostInterstitial and ChartboostRewardedVideo in the same app.

1) Setup both ad units.
2) Cache ChartboosInterstitial.
3) Cache ChartboostRewardedVideo
 
Chartboost keeps a singleton reference to a single delegate through the lifecycle of the application.  Thus setting the delegate again after the initial call to cacheInterstitial will replace the reference in the Chartboost SDK with the reference passed to cacheRewardedVideo and will lead to callbacks for prior ad units to silently fail.

## Technical Changes

There is now a true singleton delegate used by both Chartboost ad types, SingletonChartboostDelegate.java.  This class is essentially the combination of the existing static classes that ChartboostInterstitial.java and ChartboostRewardedVideo.java previously defined inside their own scope.

The changeset to do this was done in as minimal a regard as possible as to the original code.  So this is mostly just moving existing code to a  new file, updating a few scoping variables, and renaming a couple variables to be a bit more clear on their intended purpose.

## Links (optional)


## Review

@rsatrasala 

## CC
