### PR TITLE
Fixes issue where autoplay on Android requires user interaction

### DIFF
--- a/mopub-sdk/src/main/java/com/mopub/mraid/MraidBridge.java
+++ b/mopub-sdk/src/main/java/com/mopub/mraid/MraidBridge.java
@@ -106,6 +106,10 @@ public class MraidBridge {
         mMraidWebView = mraidWebView;
         mMraidWebView.getSettings().setJavaScriptEnabled(true);
 
+        if (android.os.Build.VERSION.SDK_INT>=17) {
+            mMraidWebView.getSettings().setMediaPlaybackRequiresUserGesture(false);
+        }
+
         mMraidWebView.loadUrl("javascript:" + FILTERED_JAVASCRIPT_SOURCE);
         mMraidWebView.setScrollContainer(false);
         mMraidWebView.setVerticalScrollBarEnabled(false);


### PR DESCRIPTION
Wasn't sure if you guys left this out intentionally.  I've looked through the change logs and readme and it wasn't mentioned if autoplay (w/o user interaction) was supported or not.  When I tried on my Samsung Galaxy III (4.4.2), it wasn't working, but after I set this flag to false, it would autoplay.

closes #152