### PR TITLE
Release audio focus acquired by VideoView

### DIFF
--- a/mopub-sdk/src/main/java/com/mopub/mobileads/BaseVideoPlayerActivity.java
+++ b/mopub-sdk/src/main/java/com/mopub/mobileads/BaseVideoPlayerActivity.java
@@ -54,5 +54,15 @@ public class BaseVideoPlayerActivity extends Activity {
         intentVideoPlayerActivity.putExtra(BROADCAST_IDENTIFIER_KEY, broadcastIdentifier);
         return intentVideoPlayerActivity;
     }
+
+    @Override
+    protected void onDestroy() {
+        // release audio focus which is acquired by the VideoView, but never released, leaking the Activity
+        // https://code.google.com/p/android/issues/detail?id=152173
+        AudioManager am = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+        am.abandonAudioFocus(null);
+
+        super.onDestroy();
+    }
 }
 


### PR DESCRIPTION
Implementations of this Activity use VideoViews which may leak the Activity due to retaining audio focus. This release audio focus to make sure the Activity can be garbage collected. The issue is documented here:
https://code.google.com/p/android/issues/detail?id=152173