### PR TITLE
Adblade integration.

### DIFF
--- a/extras/src/com/mopub/mobileads/AdbladeBanner.java
+++ b/extras/src/com/mopub/mobileads/AdbladeBanner.java
@@ -1,0 +1,141 @@
+package com.mopub.mobileads;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.Log;
+import android.view.ViewGroup;
+
+import com.adiant.android.ads.AdView;
+import com.adiant.android.ads.core.AdSize;
+import com.adiant.android.ads.core.ErrorReason;
+import com.adiant.android.ads.util.AdListener;
+import com.mopub.common.DataKeys;
+import com.mopub.common.util.Views;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Tested with Adblade 1.1.1
+ */
+public class AdbladeBanner extends CustomEventBanner {
+    private static final String LOG_TAG = "MoPub";
+    private static final String CONTAINER_ID_KEY = "container_id";
+
+    private static class AdbladeAdListener extends AdListener {
+        private final AdView adView;
+        private final CustomEventBannerListener mopubListener;
+
+        public AdbladeAdListener(AdView adView, CustomEventBannerListener mopubListener) {
+            this.adView = adView;
+            this.mopubListener = mopubListener;
+        }
+
+        @Override
+        public void onAdLoaded(Object ad) {
+            Log.d(LOG_TAG, "Adblade banner ad loaded successfully. Showing ad...");
+            mopubListener.onBannerLoaded(adView);
+        }
+
+        @Override
+        public void onAdLeftApplication() {
+            Log.d(LOG_TAG, "Adblade banner ad left application.");
+            mopubListener.onLeaveApplication();
+        }
+
+        @Override
+        public void onAdLoadFailed(final ErrorReason error) {
+            Log.d(LOG_TAG, "Adblade banner ad failed to load.");
+            if (error == ErrorReason.NO_FILL) {
+                mopubListener.onBannerFailed(MoPubErrorCode.NETWORK_NO_FILL);
+            } else if (error == ErrorReason.NETWORK) {
+                mopubListener.onBannerFailed(MoPubErrorCode.NETWORK_INVALID_STATE);
+            } else {
+                mopubListener.onBannerFailed(MoPubErrorCode.UNSPECIFIED);
+            }
+        }
+
+        @Override
+        public void onAdClicked() {
+            Log.d(LOG_TAG, "Adblade banner ad clicked.");
+            mopubListener.onBannerClicked();
+        }
+    }
+
+    private static boolean areServerExtrasValid(final Map<String, String> serverExtras) {
+        final String containerId = serverExtras.get(CONTAINER_ID_KEY);
+        return containerId != null && !containerId.isEmpty();
+    }
+
+    private static boolean areLocalExtrasValid(@NonNull final Map<String, Object> localExtras) {
+        return localExtras.get(DataKeys.AD_WIDTH) instanceof Integer
+                && localExtras.get(DataKeys.AD_HEIGHT) instanceof Integer;
+    }
+
+    @Nullable
+    private static AdSize calculateAdSize(int width, int height) {
+        // Use the smallest AdSize that will properly contain the adView
+        for (Map.Entry<Integer, AdSize> size : sizes().entrySet()) {
+            if (height <= size.getKey()) {
+                return size.getValue();
+            }
+        }
+        return null;
+    }
+
+    private static Map<Integer, AdSize> sizes() {
+        // get all sizes, and sort by height ascending
+        final Map<Integer, AdSize> sizesByHeight = new TreeMap<>();
+        for (AdSize s : AdSize.values()) {
+            sizesByHeight.put(s.types().iterator().next().height(), s);
+        }
+        return sizesByHeight;
+    }
+
+    private AdView adView;
+
+    @Override
+    protected void loadBanner(Context context, CustomEventBannerListener mopubListener,
+                              Map<String, Object> localExtras, Map<String, String> serverExtras) {
+        final String containerId;
+        if (areServerExtrasValid(serverExtras)) {
+            containerId = serverExtras.get(CONTAINER_ID_KEY);
+        } else {
+            mopubListener.onBannerFailed(MoPubErrorCode.ADAPTER_CONFIGURATION_ERROR);
+            return;
+        }
+
+        int width;
+        int height;
+        if (areLocalExtrasValid(localExtras)) {
+            width = (Integer) localExtras.get(DataKeys.AD_WIDTH);
+            height = (Integer) localExtras.get(DataKeys.AD_HEIGHT);
+        } else {
+            mopubListener.onBannerFailed(MoPubErrorCode.ADAPTER_CONFIGURATION_ERROR);
+            return;
+        }
+
+        final AdSize adSize = calculateAdSize(width, height);
+        if (adSize == null) {
+            mopubListener.onBannerFailed(MoPubErrorCode.ADAPTER_CONFIGURATION_ERROR);
+            return;
+        }
+
+        adView = new AdView(context);
+        adView.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT));
+        adView.setAdListener(new AdbladeAdListener(adView, mopubListener));
+        adView.setAdSize(adSize);
+        adView.setAdUnitId(containerId);
+        adView.loadAd();
+    }
+
+    @Override
+    protected void onInvalidate() {
+        if (adView != null) {
+            Views.removeFromParent(adView);
+            adView = null;
+        }
+    }
+}

--- a/extras/src/com/mopub/mobileads/AdbladeInterstitial.java
+++ b/extras/src/com/mopub/mobileads/AdbladeInterstitial.java
@@ -1,0 +1,109 @@
+package com.mopub.mobileads;
+
+import android.content.Context;
+import android.util.Log;
+
+import com.adiant.android.ads.InterstitialAd;
+import com.adiant.android.ads.core.ErrorReason;
+import com.adiant.android.ads.util.AdListener;
+
+import java.util.Map;
+
+/**
+ * Tested with Adblade 1.1.1
+ */
+public class AdbladeInterstitial extends CustomEventInterstitial {
+    private static final String LOG_TAG = "MoPub";
+    private static final String CONTAINER_ID_KEY = "container_id";
+
+    private static class AdbladeAdListener extends AdListener {
+        private final CustomEventInterstitialListener mopubListener;
+
+        public AdbladeAdListener(CustomEventInterstitialListener mopubListener) {
+            this.mopubListener = mopubListener;
+        }
+
+        @Override
+        public void onAdLoaded(Object ad) {
+            Log.d(LOG_TAG, "Adblade interstitial ad loaded successfully.");
+            mopubListener.onInterstitialLoaded();
+        }
+
+        @Override
+        public void onAdLeftApplication() {
+            Log.d(LOG_TAG, "Adblade interstitial ad left application.");
+            mopubListener.onLeaveApplication();
+        }
+
+        @Override
+        public void onAdLoadFailed(final ErrorReason error) {
+            Log.d(LOG_TAG, "Adblade interstitial ad failed to load.");
+            if (error == ErrorReason.NO_FILL) {
+                mopubListener.onInterstitialFailed(MoPubErrorCode.NETWORK_NO_FILL);
+            } else if (error == ErrorReason.NETWORK) {
+                mopubListener.onInterstitialFailed(MoPubErrorCode.NETWORK_INVALID_STATE);
+            } else {
+                mopubListener.onInterstitialFailed(MoPubErrorCode.UNSPECIFIED);
+            }
+        }
+
+        @Override
+        public void onAdClicked() {
+            Log.d(LOG_TAG, "Adblade interstitial ad clicked.");
+            mopubListener.onInterstitialClicked();
+        }
+
+        @Override
+        public void onAdClosed() {
+            Log.d(LOG_TAG, "Adblade interstitial ad dismissed.");
+            mopubListener.onInterstitialDismissed();
+        }
+
+        @Override
+        public void onAdOpened() {
+            Log.d(LOG_TAG, "Showing Adblade interstitial ad.");
+            mopubListener.onInterstitialShown();
+        }
+    }
+
+    private static boolean areServerExtrasValid(final Map<String, String> serverExtras) {
+        final String containerId = serverExtras.get(CONTAINER_ID_KEY);
+        return containerId != null && !containerId.isEmpty();
+    }
+
+    private InterstitialAd interstitial;
+
+    @Override
+    protected void loadInterstitial(Context context, CustomEventInterstitialListener mopubListener,
+                                    Map<String, Object> localExtras, Map<String, String> serverExtras) {
+        final String containerId;
+        if (areServerExtrasValid(serverExtras)) {
+            containerId = serverExtras.get(CONTAINER_ID_KEY);
+        } else {
+            mopubListener.onInterstitialFailed(MoPubErrorCode.ADAPTER_CONFIGURATION_ERROR);
+            return;
+        }
+
+        interstitial = new InterstitialAd(context);
+        interstitial.setAdListener(new AdbladeAdListener(mopubListener));
+        interstitial.setAdUnitId(containerId);
+        interstitial.loadAd();
+    }
+
+    @Override
+    protected void showInterstitial() {
+        if (interstitial != null && interstitial.isLoaded()) {
+            interstitial.show();
+        } else {
+            Log.d(LOG_TAG, "Tried to show an Adblade interstitial ad before it finished loading. Please try again.");
+        }
+    }
+
+    @Override
+    protected void onInvalidate() {
+        if (interstitial != null) {
+            interstitial.destroy();
+            interstitial = null;
+        }
+    }
+}

--- a/extras/src/com/mopub/nativeads/AdbladeNative.java
+++ b/extras/src/com/mopub/nativeads/AdbladeNative.java
@@ -1,0 +1,107 @@
+package com.mopub.nativeads;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.util.Log;
+
+import com.adiant.android.ads.NewsbulletFactory;
+import com.adiant.android.ads.core.ErrorReason;
+import com.adiant.android.ads.core.Newsbullet;
+import com.adiant.android.ads.util.AdListener;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Tested with Adblade 1.1.1
+ */
+public class AdbladeNative extends CustomEventNative {
+    public static final String EXTRA_DISPLAY_NAME = "display_name";
+
+    private static final String LOG_TAG = "MoPub";
+    private static final String CONTAINER_ID_KEY = "container_id";
+
+    private static class AdbladeAdListener extends AdListener {
+        private final AdbladeForwardingNativeAd ad;
+        private final CustomEventNativeListener mopubListener;
+
+        public AdbladeAdListener(AdbladeForwardingNativeAd ad, CustomEventNativeListener mopubListener) {
+            this.ad = ad;
+            this.mopubListener = mopubListener;
+        }
+
+        @Override
+        public void onAdLoaded(Object result) {
+            Log.d(LOG_TAG, "Adblade native ad loaded successfully. Caching images...");
+            Newsbullet nb = (Newsbullet) result;
+            ad.adLoaded(nb);
+            BaseForwardingNativeAd.preCacheImages(ad.getContext(), Collections.singletonList(nb.getBannerUrl()), new ImageListener() {
+                @Override
+                public void onImagesCached() {
+                    Log.d(LOG_TAG, "Adblade native ad images cached successfully.");
+                    mopubListener.onNativeAdLoaded(ad);
+                }
+
+                @Override
+                public void onImagesFailedToCache(NativeErrorCode errorCode) {
+                    Log.d(LOG_TAG, "Adblade native ad images failed to cache.");
+                    mopubListener.onNativeAdFailed(errorCode);
+                }
+            });
+        }
+
+        @Override
+        public void onAdLoadFailed(final ErrorReason error) {
+            Log.d(LOG_TAG, "Adblade native ad failed to load.");
+            if (error == ErrorReason.NO_FILL) {
+                mopubListener.onNativeAdFailed(NativeErrorCode.NETWORK_NO_FILL);
+            } else if (error == ErrorReason.NETWORK) {
+                mopubListener.onNativeAdFailed(NativeErrorCode.NETWORK_INVALID_STATE);
+            } else {
+                mopubListener.onNativeAdFailed(NativeErrorCode.UNSPECIFIED);
+            }
+        }
+    }
+
+    private static class AdbladeForwardingNativeAd extends BaseForwardingNativeAd {
+        private final Context context;
+
+        public AdbladeForwardingNativeAd(Context context) {
+            this.context = context;
+        }
+
+        public void adLoaded(Newsbullet ad) {
+            setClickDestinationUrl(ad.getClickUrl());
+            setMainImageUrl(ad.getBannerUrl());
+            setText(ad.getDescription());
+            setTitle(ad.getTitle());
+            addExtra(EXTRA_DISPLAY_NAME, ad.getDisplayName());
+        }
+
+        public Context getContext() {
+            return context;
+        }
+    }
+
+    private static boolean areServerExtrasValid(final Map<String, String> serverExtras) {
+        final String containerId = serverExtras.get(CONTAINER_ID_KEY);
+        return containerId != null && !containerId.isEmpty();
+    }
+
+    @Override
+    protected void loadNativeAd(@NonNull Context context,
+                                @NonNull CustomEventNativeListener mopubListener,
+                                @NonNull Map<String, Object> localExtras,
+                                @NonNull Map<String, String> serverExtras) {
+        final String containerId;
+        if (areServerExtrasValid(serverExtras)) {
+            containerId = serverExtras.get(CONTAINER_ID_KEY);
+        } else {
+            mopubListener.onNativeAdFailed(NativeErrorCode.NATIVE_ADAPTER_CONFIGURATION_ERROR);
+            return;
+        }
+
+        new NewsbulletFactory(containerId, context).loadAd(new AdbladeAdListener(
+                new AdbladeForwardingNativeAd(context), mopubListener));
+    }
+}


### PR DESCRIPTION
Adblade has released its Android ads SDK. Please see https://github.com/adiant/android-sdk-example

We would like to add our mediation adapters to the MoPub SDK. We've authored adapters for banner, interstitial, and native ads.
