### PR TITLE
Call adDidFail if adLoader is null

### DIFF
--- a/mopub-sdk/src/main/java/com/mopub/mobileads/AdViewController.java
+++ b/mopub-sdk/src/main/java/com/mopub/mobileads/AdViewController.java
@@ -146,6 +146,10 @@ public class AdViewController {
         if (adLoader != null) {
             adLoader.load();
         }
+        else  {
+            MoPubLog.d("Can't load an ad because adLoader is null");
+            adDidFail(MoPubErrorCode.INTERNAL_ERROR);
+        }
         scheduleRefreshTimerIfEnabled();
     }
 


### PR DESCRIPTION
Call adDidFail in case AdLoader.fromAdResponse fails to return a valid AdLoader