### PR TITLE
Handle "intent://" links via UrlAction

### DIFF
--- a/mopub-sdk/src/main/java/com/mopub/common/BrowserWebViewClient.java
+++ b/mopub-sdk/src/main/java/com/mopub/common/BrowserWebViewClient.java
@@ -25,7 +25,8 @@ class BrowserWebViewClient extends WebViewClient {
             UrlAction.OPEN_IN_APP_BROWSER,
             UrlAction.HANDLE_SHARE_TWEET,
             UrlAction.FOLLOW_DEEP_LINK_WITH_FALLBACK,
-            UrlAction.FOLLOW_DEEP_LINK
+            UrlAction.FOLLOW_DEEP_LINK,
+            UrlAction.FOLLOW_INTENT_LINK
     );
 
     @NonNull

--- a/mopub-sdk/src/main/java/com/mopub/common/UrlAction.java
+++ b/mopub-sdk/src/main/java/com/mopub/common/UrlAction.java
@@ -275,6 +275,19 @@ public enum UrlAction {
         }
     },
 
+    /* 9 */ FOLLOW_INTENT_LINK(true) {
+        @Override
+        public boolean shouldTryHandlingUrl(@NonNull Uri uri) {
+            final String scheme = uri.getScheme();
+            return !TextUtils.isEmpty(scheme) && scheme.equals("intent");
+        }
+
+        @Override
+        protected void performAction(@NonNull Context context, @NonNull Uri uri, @NonNull UrlHandler urlHandler) throws IntentNotResolvableException {
+            Intents.launchIntentUrl(context, uri);
+        }
+    },
+
     /* This is essentially an "unspecified" value for UrlAction. */
     NOOP(false) {
         @Override

--- a/mopub-sdk/src/main/java/com/mopub/mobileads/HtmlWebViewClient.java
+++ b/mopub-sdk/src/main/java/com/mopub/mobileads/HtmlWebViewClient.java
@@ -30,7 +30,8 @@ class HtmlWebViewClient extends WebViewClient {
             UrlAction.OPEN_IN_APP_BROWSER,
             UrlAction.HANDLE_SHARE_TWEET,
             UrlAction.FOLLOW_DEEP_LINK_WITH_FALLBACK,
-            UrlAction.FOLLOW_DEEP_LINK);
+            UrlAction.FOLLOW_DEEP_LINK,
+            UrlAction.FOLLOW_INTENT_LINK);
 
     private final Context mContext;
     private HtmlWebViewListener mHtmlWebViewListener;


### PR DESCRIPTION
Created another UrlAction (#9) to properly handle "intent://" scheme deeplinks.

Per "intent://" spec, we parse the Intent. Attempt to open the corresponding activity.
If this fails, we check the package. If the package exists, we open the play store to the package listing.

Cheers