### PR TITLE
Explicitly declare class as public

### DIFF
--- a/extras/src/com/mopub/nativeads/InMobiNative.java
+++ b/extras/src/com/mopub/nativeads/InMobiNative.java
@@ -28,7 +28,7 @@ import static com.mopub.nativeads.NativeImageHelper.preCacheImages;
 /*
  * Tested with InMobi SDK 4.4.1
  */
-class InMobiNative extends CustomEventNative {
+public class InMobiNative extends CustomEventNative {
     private static final String APP_ID_KEY = "app_id";
 
     // CustomEventNative implementation


### PR DESCRIPTION
Explicitly change access level to public, same as FacebookNative (https://github.com/mopub/mopub-android-sdk/blob/master/extras/src/com/mopub/nativeads/FacebookNative.java) and MillennialNative (https://github.com/mopub/mopub-android-sdk/blob/master/extras/src/com/mopub/nativeads/MillennialNative.java)
