### PR TITLE
fixes Chartboost.setFramework

### DIFF
--- a/extras/src/com/mopub/mobileads/ChartboostShared.java
+++ b/extras/src/com/mopub/mobileads/ChartboostShared.java
@@ -75,7 +75,7 @@ public class ChartboostShared {
         // Perform all the common SDK initialization steps including startAppWithId
         Chartboost.startWithAppId(launcherActivity, mAppId, mAppSignature);
         Chartboost.setImpressionsUseActivities(false);
-        Chartboost.setFramework(Chartboost.CBFramework.CBFrameworkMoPub);
+        Chartboost.setFramework(Chartboost.CBMediation.CBMediationMoPub);
         Chartboost.setDelegate(sDelegate);
         Chartboost.setShouldRequestInterstitialsInFirstSession(true);
         Chartboost.setAutoCacheAds(false);


### PR DESCRIPTION
-in 6.1.0 CBFramework.CBFrameworkMoPub was updated to a different enum, CBMediation.CBMediationMoPub
-reported here: http://stackoverflow.com/questions/33798283/chartboost-adapter-code-error-with-mopub-mediation
