### PR TITLE
Update signature to activity

### DIFF
--- a/extras/src/com/mopub/nativeads/FacebookNative.java
+++ b/extras/src/com/mopub/nativeads/FacebookNative.java
@@ -56,10 +56,10 @@ public class FacebookNative extends CustomEventNative {
         private final NativeAd mNativeAd;
         private final CustomEventNativeListener mCustomEventNativeListener;
 
-        FacebookStaticNativeAd(final Context context,
+        FacebookStaticNativeAd(final Activity activity,
                 final NativeAd nativeAd,
                 final CustomEventNativeListener customEventNativeListener) {
-            mContext = context.getApplicationContext();
+            mContext = activity.getApplicationContext();
             mNativeAd = nativeAd;
             mCustomEventNativeListener = customEventNativeListener;
         }


### PR DESCRIPTION
SDK v4.1.0 was updated to pass in activity to the FacebookStaticNativeAd method, but the signature was using an old reference to context causing an implicit and potentially unclear conversion from activity to context