### PR TITLE
Fixes getting the root view

### DIFF
--- a/mopub-sdk/src/main/java/com/mopub/mraid/MraidController.java
+++ b/mopub-sdk/src/main/java/com/mopub/mraid/MraidController.java
@@ -838,8 +838,7 @@ public class MraidController {
                 Preconditions.checkState(mDefaultAdContainer.isAttachedToWindow());
             }
 
-            mRootView = (ViewGroup) mDefaultAdContainer.getRootView().findViewById(
-                    android.R.id.content);
+            mRootView = (ViewGroup) mDefaultAdContainer.getRootView();
         }
 
         return mRootView;


### PR DESCRIPTION
There is an issue in MRAID ads where the fetched root view is null. I believe this to be due the parsing the return of mDefaultAdContainer.getRootView() lookomg for a view with id android.R.id.content.
When the root view does not correspond with the contents of the activity, for example if it is created dinamycally (see [an example in the nullrootview module of this branch in my fork](https://github.com/stoyicker/mopub-android-sdk/blob/cb3d0cd0aae51bac9f71998cb4844b39bdb637d1/nullrootview/src/main/java/com/example/nullrootview/MainActivity.java)), there is no view with that id.

This is not covered by MraidControllerTest since an alternate root view is enforced there instead.

TL;DR http://stackoverflow.com/questions/10668330/difference-between-findviewbyidr-id-content-and-getrootview
