### PR TITLE
Tapjoy SDK 11.5 update

### DIFF
--- a/extras/src/com/mopub/mobileads/TapjoyInterstitial.java
+++ b/extras/src/com/mopub/mobileads/TapjoyInterstitial.java
@@ -1,6 +1,8 @@
 package com.mopub.mobileads;
 
 import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
 import android.text.TextUtils;
 
 import com.mopub.common.logging.MoPubLog;
@@ -13,14 +15,15 @@ import com.tapjoy.TapjoyLog;
 
 import java.util.Map;
 
-// Tested with Tapjoy SDK 11.5.0
+// Tested with Tapjoy SDK 11.5.1
 public class TapjoyInterstitial extends CustomEventInterstitial implements TJPlacementListener {
     private static final String TAG = TapjoyInterstitial.class.getSimpleName();
     private static final String TJC_MOPUB_NETWORK_CONSTANT = "mopub";
-    private static final String TJC_MOPUB_ADAPTER_VERSION_NUMBER = "3.0.0";
+    private static final String TJC_MOPUB_ADAPTER_VERSION_NUMBER = "4.0.0";
 
     private TJPlacement tjPlacement;
     private CustomEventInterstitialListener mInterstitialListener;
+    private Handler mHandler;
 
     static {
         TapjoyLog.i(TAG, "Class initialized with network adapter version " + TJC_MOPUB_ADAPTER_VERSION_NUMBER);
@@ -34,6 +37,7 @@ public class TapjoyInterstitial extends CustomEventInterstitial implements TJPla
         MoPubLog.d("Requesting Tapjoy interstitial");
 
         mInterstitialListener = customEventInterstitialListener;
+        mHandler = new Handler(Looper.getMainLooper());
 
         String name = serverExtras.get("name");
         if (TextUtils.isEmpty(name)) {
@@ -59,32 +63,55 @@ public class TapjoyInterstitial extends CustomEventInterstitial implements TJPla
     // Tapjoy
 
     @Override
-    public void onRequestSuccess(TJPlacement placement) {
-        if (placement.isContentAvailable()) {
-            MoPubLog.d("Tapjoy interstitial request successful");
-            mInterstitialListener.onInterstitialLoaded();
-        } else {
-            MoPubLog.d("No Tapjoy interstitials available");
-            mInterstitialListener.onInterstitialFailed(MoPubErrorCode.NETWORK_NO_FILL);
-        }
+    public void onRequestSuccess(final TJPlacement placement) {
+        mHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                if (placement.isContentAvailable()) {
+                    MoPubLog.d("Tapjoy interstitial request successful");
+                    mInterstitialListener.onInterstitialLoaded();
+                } else {
+                    MoPubLog.d("No Tapjoy interstitials available");
+                    mInterstitialListener.onInterstitialFailed(MoPubErrorCode.NETWORK_NO_FILL);
+                }
+            }
+        });
     }
 
     @Override
     public void onRequestFailure(TJPlacement placement, TJError error) {
         MoPubLog.d("Tapjoy interstitial request failed");
-        mInterstitialListener.onInterstitialFailed(MoPubErrorCode.NETWORK_NO_FILL);
+
+        mHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                mInterstitialListener.onInterstitialFailed(MoPubErrorCode.NETWORK_NO_FILL);
+            }
+        });
     }
 
     @Override
     public void onContentShow(TJPlacement placement) {
         MoPubLog.d("Tapjoy interstitial shown");
-        mInterstitialListener.onInterstitialShown();
+
+        mHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                mInterstitialListener.onInterstitialShown();
+            }
+        });
     }
 
     @Override
     public void onContentDismiss(TJPlacement placement) {
         MoPubLog.d("Tapjoy interstitial dismissed");
-        mInterstitialListener.onInterstitialDismissed();
+
+        mHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                mInterstitialListener.onInterstitialDismissed();
+            }
+        });
     }
 
     @Override

--- a/extras/src/com/mopub/mobileads/TapjoyInterstitial.java
+++ b/extras/src/com/mopub/mobileads/TapjoyInterstitial.java
@@ -8,19 +8,29 @@ import com.tapjoy.TJActionRequest;
 import com.tapjoy.TJError;
 import com.tapjoy.TJPlacement;
 import com.tapjoy.TJPlacementListener;
+import com.tapjoy.TapjoyConstants;
+import com.tapjoy.TapjoyLog;
 
 import java.util.Map;
 
-// Tested with Tapjoy SDK 11.1.0
+// Tested with Tapjoy SDK 11.5.0
 public class TapjoyInterstitial extends CustomEventInterstitial implements TJPlacementListener {
+    private static final String TAG = TapjoyInterstitial.class.getSimpleName();
+    private static final String TJC_MOPUB_NETWORK_CONSTANT = "mopub";
+    private static final String TJC_MOPUB_ADAPTER_VERSION_NUMBER = "3.0.0";
+
     private TJPlacement tjPlacement;
     private CustomEventInterstitialListener mInterstitialListener;
 
+    static {
+        TapjoyLog.i(TAG, "Class initialized with network adapter version " + TJC_MOPUB_ADAPTER_VERSION_NUMBER);
+    }
+
     @Override
     protected void loadInterstitial(Context context,
-            CustomEventInterstitialListener customEventInterstitialListener,
-            Map<String, Object> localExtras,
-            Map<String, String> serverExtras) {
+                                    CustomEventInterstitialListener customEventInterstitialListener,
+                                    Map<String, Object> localExtras,
+                                    Map<String, String> serverExtras) {
         MoPubLog.d("Requesting Tapjoy interstitial");
 
         mInterstitialListener = customEventInterstitialListener;
@@ -30,6 +40,8 @@ public class TapjoyInterstitial extends CustomEventInterstitial implements TJPla
             MoPubLog.d("Tapjoy interstitial loaded with empty 'name' field. Request will fail.");
         }
         tjPlacement = new TJPlacement(context, name, this);
+        tjPlacement.setMediationName(TJC_MOPUB_NETWORK_CONSTANT);
+        tjPlacement.setAdapterVersion(TJC_MOPUB_ADAPTER_VERSION_NUMBER);
         tjPlacement.requestContent();
     }
 
@@ -81,12 +93,12 @@ public class TapjoyInterstitial extends CustomEventInterstitial implements TJPla
 
     @Override
     public void onPurchaseRequest(TJPlacement placement, TJActionRequest request,
-            String productId) {
+                                  String productId) {
     }
 
     @Override
     public void onRewardRequest(TJPlacement placement, TJActionRequest request, String itemId,
-            int quantity) {
+                                int quantity) {
     }
 
 }

--- a/extras/src/com/mopub/mobileads/TapjoyRewardedVideo.java
+++ b/extras/src/com/mopub/mobileads/TapjoyRewardedVideo.java
@@ -2,23 +2,41 @@ package com.mopub.mobileads;
 
 import android.app.Activity;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.mopub.common.LifecycleListener;
 import com.mopub.common.MediationSettings;
+import com.mopub.common.MoPubReward;
 import com.mopub.common.logging.MoPubLog;
 import com.tapjoy.TJActionRequest;
+import com.tapjoy.TJConnectListener;
 import com.tapjoy.TJError;
 import com.tapjoy.TJPlacement;
 import com.tapjoy.TJPlacementListener;
+import com.tapjoy.TJVideoListener;
+import com.tapjoy.Tapjoy;
+import com.tapjoy.TapjoyConstants;
+import com.tapjoy.TapjoyLog;
 
+import java.util.Hashtable;
 import java.util.Map;
 
-// Tested with Tapjoy SDK 11.1.0
+// Tested with Tapjoy SDK 11.5.0
 public class TapjoyRewardedVideo extends CustomEventRewardedVideo {
+    private static final String TAG = TapjoyRewardedVideo.class.getSimpleName();
+    private static final String TJC_MOPUB_NETWORK_CONSTANT = "mopub";
+    private static final String TJC_MOPUB_ADAPTER_VERSION_NUMBER = "3.0.0";
     private static final String TAPJOY_AD_NETWORK_CONSTANT = "tapjoy_id";
+
+    private String sdkKey;
+    private Hashtable<String, Object> connectFlags;
     private TJPlacement tjPlacement;
     private static TapjoyRewardedVideoListener sTapjoyListener = new TapjoyRewardedVideoListener();
+
+    static {
+        TapjoyLog.i(TAG, "Class initialized with network adapter version " + TJC_MOPUB_ADAPTER_VERSION_NUMBER);
+    }
 
     @Override
     protected CustomEventRewardedVideoListener getVideoListenerForSdk() {
@@ -41,17 +59,39 @@ public class TapjoyRewardedVideo extends CustomEventRewardedVideo {
 
     @Override
     protected boolean checkAndInitializeSdk(@NonNull Activity launcherActivity,
-            @NonNull Map<String, Object> localExtras,
-            @NonNull Map<String, String> serverExtras)
+                                            @NonNull Map<String, Object> localExtras,
+                                            @NonNull Map<String, String> serverExtras)
             throws Exception {
-        // Always return false, no special initialization steps to be done from here
+
+        if (!Tapjoy.isConnected()) {
+            if (checkAndInitMediationSettings()) {
+                MoPubLog.d("Request to connect to Tapjoy");
+
+                Tapjoy.connect(launcherActivity, sdkKey, connectFlags, new TJConnectListener() {
+                    @Override
+                    public void onConnectSuccess() {
+                        MoPubLog.d("Tapjoy connected successfully");
+                    }
+
+                    @Override
+                    public void onConnectFailure() {
+                        MoPubLog.e("Tapjoy connect failed");
+                    }
+                });
+
+                return true;
+            } else {
+                MoPubLog.d("Cannot connect to Tapjoy -- missing 'sdkkey' declaration via TapjoyMediationSettings");
+            }
+        }
+
         return false;
     }
 
     @Override
     protected void loadWithSdkInitialized(@NonNull Activity activity,
-            @NonNull Map<String, Object> localExtras,
-            @NonNull Map<String, String> serverExtras)
+                                          @NonNull Map<String, Object> localExtras,
+                                          @NonNull Map<String, String> serverExtras)
             throws Exception {
         MoPubLog.d("Requesting Tapjoy rewarded video");
 
@@ -60,6 +100,8 @@ public class TapjoyRewardedVideo extends CustomEventRewardedVideo {
             MoPubLog.d("Tapjoy interstitial loaded with empty 'name' field. Request will fail.");
         }
         tjPlacement = new TJPlacement(activity, name, sTapjoyListener);
+        tjPlacement.setMediationName(TJC_MOPUB_NETWORK_CONSTANT);
+        tjPlacement.setAdapterVersion(TJC_MOPUB_ADAPTER_VERSION_NUMBER);
         tjPlacement.requestContent();
     }
 
@@ -79,10 +121,33 @@ public class TapjoyRewardedVideo extends CustomEventRewardedVideo {
 
     }
 
-    private static class TapjoyRewardedVideoListener implements TJPlacementListener, CustomEventRewardedVideoListener {
+    private boolean checkAndInitMediationSettings() {
+        MoPubLog.d("Initializing Tapjoy mediation settings");
+
+        final TapjoyMediationSettings globalMediationSettings =
+                MoPubRewardedVideoManager.getGlobalMediationSettings(TapjoyMediationSettings.class);
+
+        if (globalMediationSettings != null) {
+            if (!TextUtils.isEmpty(globalMediationSettings.getSdkKey())) {
+                sdkKey = globalMediationSettings.getSdkKey();
+            } else {
+                return false;
+            }
+
+            if (globalMediationSettings.getConnectFlags() != null) {
+                connectFlags = globalMediationSettings.getConnectFlags();
+            }
+
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private static class TapjoyRewardedVideoListener implements TJPlacementListener, CustomEventRewardedVideoListener, TJVideoListener {
         @Override
         public void onRequestSuccess(TJPlacement placement) {
-            if (!placement.isContentAvailable()) {
+            if (!placement.isContentAvailable()){
                 MoPubLog.d("No Tapjoy rewarded videos available");
                 MoPubRewardedVideoManager.onRewardedVideoLoadFailure(TapjoyRewardedVideo.class, TAPJOY_AD_NETWORK_CONSTANT, MoPubErrorCode.NETWORK_NO_FILL);
             }
@@ -102,30 +167,67 @@ public class TapjoyRewardedVideo extends CustomEventRewardedVideo {
 
         @Override
         public void onContentShow(TJPlacement placement) {
+            Tapjoy.setVideoListener(this);
             MoPubLog.d("Tapjoy rewarded video content shown");
             MoPubRewardedVideoManager.onRewardedVideoStarted(TapjoyRewardedVideo.class, TAPJOY_AD_NETWORK_CONSTANT);
         }
 
         @Override
         public void onContentDismiss(TJPlacement placement) {
+            Tapjoy.setVideoListener(null);
             MoPubLog.d("Tapjoy rewarded video content dismissed");
             MoPubRewardedVideoManager.onRewardedVideoClosed(TapjoyRewardedVideo.class, TAPJOY_AD_NETWORK_CONSTANT);
         }
 
         @Override
         public void onPurchaseRequest(TJPlacement placement, TJActionRequest request,
-                String productId) {
+                                      String productId) {
         }
 
         @Override
         public void onRewardRequest(TJPlacement placement, TJActionRequest request, String itemId,
-                int quantity) {
+                                    int quantity) {
+        }
+
+        @Override
+        public void onVideoStart() {
+
+        }
+
+        @Override
+        public void onVideoError(int statusCode) {
+        }
+
+        @Override
+        public void onVideoComplete() {
+            MoPubLog.d("Tapjoy rewarded video completed");
+            MoPubRewardedVideoManager.onRewardedVideoCompleted(TapjoyRewardedVideo.class, TAPJOY_AD_NETWORK_CONSTANT, MoPubReward.success(MoPubReward.NO_REWARD_LABEL, MoPubReward.NO_REWARD_AMOUNT));
         }
     }
 
     public static final class TapjoyMediationSettings implements MediationSettings {
-        public TapjoyMediationSettings() {
+        @Nullable
+        private final String mSdkKey;
+        @Nullable
+        Hashtable<String, Object> mConnectFlags;
 
+        public TapjoyMediationSettings(String sdkKey) {
+            this.mSdkKey = sdkKey;
+        }
+
+        public TapjoyMediationSettings(String sdkKey, Hashtable<String, Object> connectFlags) {
+            this.mSdkKey = sdkKey;
+            this.mConnectFlags = connectFlags;
+        }
+
+        @NonNull
+        public String getSdkKey() {
+            return mSdkKey;
+        }
+
+        @NonNull
+        public Hashtable<String, Object> getConnectFlags() {
+            return mConnectFlags;
         }
     }
 

--- a/extras/src/com/mopub/mobileads/TapjoyRewardedVideo.java
+++ b/extras/src/com/mopub/mobileads/TapjoyRewardedVideo.java
@@ -22,11 +22,11 @@ import com.tapjoy.TapjoyLog;
 import java.util.Hashtable;
 import java.util.Map;
 
-// Tested with Tapjoy SDK 11.5.0
+// Tested with Tapjoy SDK 11.5.1
 public class TapjoyRewardedVideo extends CustomEventRewardedVideo {
     private static final String TAG = TapjoyRewardedVideo.class.getSimpleName();
     private static final String TJC_MOPUB_NETWORK_CONSTANT = "mopub";
-    private static final String TJC_MOPUB_ADAPTER_VERSION_NUMBER = "3.0.0";
+    private static final String TJC_MOPUB_ADAPTER_VERSION_NUMBER = "4.0.0";
     private static final String TAPJOY_AD_NETWORK_CONSTANT = "tapjoy_id";
 
     private String sdkKey;


### PR DESCRIPTION
Update for Tapjoy 11.5 SDK:
- Set a mediationName and adapterVersion param on our TJPlacement objects so that we can internally track these requests
- Added missing video listener to correctly fire video completion events from Tapjoy to MoPub
- Added params to TapjoyMediationSettings that can optionally be used with rewarded video initialization (current mechanism of manually calling Tapjoy connect also still works)
