### PR TITLE
checkPermission may throw RuntimException on some device

### DIFF
--- a/mopub-sdk/src/main/java/com/mopub/common/util/DeviceUtils.java
+++ b/mopub-sdk/src/main/java/com/mopub/common/util/DeviceUtils.java
@@ -253,9 +253,13 @@ public class DeviceUtils {
             @NonNull final String permission) {
         Preconditions.checkNotNull(context);
         Preconditions.checkNotNull(permission);
-
-        return ContextCompat.checkSelfPermission(context, permission) ==
-                PackageManager.PERMISSION_GRANTED;
+        try {
+        	return ContextCompat.checkSelfPermission(context, permission) ==
+                    PackageManager.PERMISSION_GRANTED;
+		} catch (Exception e) {
+			e.printStackTrace();
+			return false;
+		}
     }
 
     /**


### PR DESCRIPTION
checkPermission may throw RuntimException on some device.
We have receive some RuntimeException which is caused by "DeviceUtils.isPermissionGranted"..
