### PR TITLE
Adding a way to use includes from the SDK for better debugging.

### DIFF
--- a/mopub-sample/src/main/java/com/mopub/simpleadsdemo/MoPubSampleAdUnit.java
+++ b/mopub-sample/src/main/java/com/mopub/simpleadsdemo/MoPubSampleAdUnit.java
@@ -13,6 +13,7 @@ class MoPubSampleAdUnit implements Comparable<MoPubSampleAdUnit> {
     public static final String AD_TYPE = "adType";
     public static final String IS_USER_DEFINED = "isCustom";
     public static final String ID = "id";
+    public static final String INCLUDE = "include";
 
     // Note that entries are also sorted in this order
     enum AdType {
@@ -68,6 +69,7 @@ class MoPubSampleAdUnit implements Comparable<MoPubSampleAdUnit> {
         private String mDescription;
         private boolean mIsUserDefined;
         private long mId;
+        private String mInclude;
 
         Builder(final String adUnitId, final AdType adType) {
             mAdUnitId = adUnitId;
@@ -90,6 +92,11 @@ class MoPubSampleAdUnit implements Comparable<MoPubSampleAdUnit> {
             return this;
         }
 
+        Builder include(final String include) {
+            mInclude = include;
+            return this;
+        }
+
         MoPubSampleAdUnit build() {
             return new MoPubSampleAdUnit(this);
         }
@@ -100,6 +107,7 @@ class MoPubSampleAdUnit implements Comparable<MoPubSampleAdUnit> {
     private final String mDescription;
     private final boolean mIsUserDefined;
     private final long mId;
+    private final String mInclude;
 
     private MoPubSampleAdUnit(final Builder builder) {
         mAdUnitId = builder.mAdUnitId;
@@ -107,6 +115,7 @@ class MoPubSampleAdUnit implements Comparable<MoPubSampleAdUnit> {
         mDescription = builder.mDescription;
         mIsUserDefined = builder.mIsUserDefined;
         mId = builder.mId;
+        mInclude = builder.mInclude;
     }
 
     Class<? extends Fragment> getFragmentClass() {
@@ -137,6 +146,8 @@ class MoPubSampleAdUnit implements Comparable<MoPubSampleAdUnit> {
         return mIsUserDefined;
     }
 
+    String include() { return mInclude; }
+
     Bundle toBundle() {
         final Bundle bundle = new Bundle();
         bundle.putLong(ID, mId);
@@ -144,6 +155,7 @@ class MoPubSampleAdUnit implements Comparable<MoPubSampleAdUnit> {
         bundle.putString(DESCRIPTION, mDescription);
         bundle.putSerializable(AD_TYPE, mAdType);
         bundle.putBoolean(IS_USER_DEFINED, mIsUserDefined);
+        bundle.putString(INCLUDE, mInclude);
 
         return bundle;
     }
@@ -154,10 +166,12 @@ class MoPubSampleAdUnit implements Comparable<MoPubSampleAdUnit> {
         final AdType adType = (AdType) bundle.getSerializable(AD_TYPE);
         final String description = bundle.getString(DESCRIPTION);
         final boolean isUserDefined = bundle.getBoolean(IS_USER_DEFINED, false);
+        final String include = bundle.getString(INCLUDE);
         final Builder builder = new MoPubSampleAdUnit.Builder(adUnitId, adType);
         builder.description(description);
         builder.id(id);
         builder.isUserDefined(isUserDefined);
+        builder.include(include);
 
         return builder.build();
     }

--- a/mopub-sdk/src/main/java/com/mopub/common/AdUrlGenerator.java
+++ b/mopub-sdk/src/main/java/com/mopub/common/AdUrlGenerator.java
@@ -28,6 +28,11 @@ public abstract class AdUrlGenerator extends BaseUrlGenerator {
     private static final String KEYWORDS_KEY = "q";
 
     /**
+     * include = ad group ID to specifically target only those ad groups we want to be in the auction.
+     */
+    private static final String DEBUG_INCLUDES_KEY = "include";
+
+    /**
      * Location represented in latitude and longitude.
      * e.g. "47.638,-122.321"
      */
@@ -105,6 +110,7 @@ public abstract class AdUrlGenerator extends BaseUrlGenerator {
     protected String mAdUnitId;
     protected String mKeywords;
     protected Location mLocation;
+    protected String mIncludes;
 
     public AdUrlGenerator(Context context) {
         mContext = context;
@@ -125,6 +131,11 @@ public abstract class AdUrlGenerator extends BaseUrlGenerator {
         return this;
     }
 
+    public AdUrlGenerator withDebugIncludes(String includes) {
+        mIncludes = includes;
+        return this;
+    }
+
     protected void setAdUnitId(String adUnitId) {
         addParam(AD_UNIT_ID_KEY, adUnitId);
     }
@@ -135,6 +146,10 @@ public abstract class AdUrlGenerator extends BaseUrlGenerator {
 
     protected void setKeywords(String keywords) {
         addParam(KEYWORDS_KEY, keywords);
+    }
+
+    protected void setIncludes(String includes) {
+        addParam(DEBUG_INCLUDES_KEY, includes);
     }
 
     protected void setLocation(@Nullable Location location) {
@@ -218,6 +233,8 @@ public abstract class AdUrlGenerator extends BaseUrlGenerator {
         setKeywords(mKeywords);
 
         setLocation(mLocation);
+
+        setIncludes(mIncludes);
 
         setTimezone(DateAndTime.getTimeZoneOffsetString());
 

--- a/mopub-sdk/src/main/java/com/mopub/mobileads/AdViewController.java
+++ b/mopub-sdk/src/main/java/com/mopub/mobileads/AdViewController.java
@@ -75,6 +75,7 @@ public class AdViewController {
     private boolean mPreviousAutoRefreshSetting = true;
     private String mKeywords;
     private Location mLocation;
+    private String mIncludes;
     private boolean mIsTesting;
     private boolean mAdWasLoaded;
     @Nullable private String mAdUnitId;
@@ -300,6 +301,14 @@ public class AdViewController {
         mLocation = location;
     }
 
+    public String getIncludes() {
+        return mIncludes;
+    }
+
+    public void setIncludes(String includes) {
+        mIncludes = includes;
+    }
+
     public String getAdUnitId() {
         return mAdUnitId;
     }
@@ -457,6 +466,7 @@ public class AdViewController {
                 .withAdUnitId(mAdUnitId)
                 .withKeywords(mKeywords)
                 .withLocation(mLocation)
+                .withDebugIncludes(mIncludes)
                 .generateUrlString(Constants.HOST);
     }
 

--- a/mopub-sdk/src/main/java/com/mopub/mobileads/MoPubInterstitial.java
+++ b/mopub-sdk/src/main/java/com/mopub/mobileads/MoPubInterstitial.java
@@ -110,6 +110,10 @@ public class MoPubInterstitial implements CustomEventInterstitialAdapter.CustomE
         mInterstitialView.setKeywords(keywords);
     }
 
+    public void setInclude(String include) {
+        mInterstitialView.setInclude(include);
+    }
+
     public String getKeywords() {
         return mInterstitialView.getKeywords();
     }

--- a/mopub-sdk/src/main/java/com/mopub/mobileads/MoPubView.java
+++ b/mopub-sdk/src/main/java/com/mopub/mobileads/MoPubView.java
@@ -253,6 +253,14 @@ public class MoPubView extends FrameLayout {
         return (mAdViewController != null) ? mAdViewController.getKeywords() : null;
     }
 
+    public void setInclude(String includes) {
+        if (mAdViewController != null) mAdViewController.setIncludes(includes);
+    }
+
+    public String getInclude() {
+        return (mAdViewController != null) ? mAdViewController.getIncludes() : null;
+    }
+
     public void setLocation(Location location) {
         if (mAdViewController != null) mAdViewController.setLocation(location);
     }


### PR DESCRIPTION
This helps in targeting a specific ad group from the SDK allowing for better targeting to a specific adapter or set of adapters by using a 'whitelist' of a single ad group that will pass the auction.