### PR TITLE
MillennialMedia Adapter updates for MMSDK-v6.3.0 (catching MMException properly)

### DIFF
--- a/extras/src/com/mopub/mobileads/MillennialBanner.java
+++ b/extras/src/com/mopub/mobileads/MillennialBanner.java
@@ -89,7 +89,7 @@ class MillennialBanner extends CustomEventBanner {
                 ai = ai.setSiteId(null);
             }
             MMSDK.setAppInfo(ai);
-        } catch ( IllegalStateException e ) {
+        } catch ( MMException e ) {
             Log.i(LOGCAT_TAG, "Caught exception " + e.getMessage());
             UI_THREAD_HANDLER.post(new Runnable() {
                 @Override
@@ -111,6 +111,10 @@ class MillennialBanner extends CustomEventBanner {
         try {
             mInlineAd = InlineAd.createInstance(apid, mInternalView);
             mInlineAdMetadata = new InlineAdMetadata().setAdSize(new AdSize(width, height));
+            mInlineAd.setListener(new MillennialInlineListener());
+
+            /* If MoPub gets location, so do we. */
+            MMSDK.setLocationEnabled( (localExtras.get("location") != null) );
         } catch ( MMException e ) {
             e.printStackTrace();
             UI_THREAD_HANDLER.post(new Runnable() {
@@ -122,10 +126,7 @@ class MillennialBanner extends CustomEventBanner {
             return;
         }
 
-        mInlineAd.setListener(new MillennialInlineListener());
-        
-        /* If MoPub gets location, so do we. */
-        MMSDK.setLocationEnabled( (localExtras.get("location") != null) );
+
 
         AdViewController.setShouldHonorServerDimensions(mInternalView);
 

--- a/extras/src/com/mopub/mobileads/MillennialInterstitial.java
+++ b/extras/src/com/mopub/mobileads/MillennialInterstitial.java
@@ -6,14 +6,14 @@ import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 
-import java.util.Map;
-
 import com.millennialmedia.AppInfo;
 import com.millennialmedia.InterstitialAd;
 import com.millennialmedia.InterstitialAd.InterstitialErrorStatus;
 import com.millennialmedia.InterstitialAd.InterstitialListener;
 import com.millennialmedia.MMException;
 import com.millennialmedia.MMSDK;
+
+import java.util.Map;
 
 /**
  * Compatible with version 6.0 of the Millennial Media SDK.
@@ -78,12 +78,13 @@ class MillennialInterstitial extends CustomEventInterstitial {
                 ai.setSiteId(null);
             }
             MMSDK.setAppInfo(ai);
-        } catch ( IllegalStateException e ) {
+            /* If MoPub gets location, so do we. */
+            MMSDK.setLocationEnabled( (localExtras.get("location") != null) );
+        } catch ( MMException e ) {
             Log.i(LOGCAT_TAG, "SDK not finished initializing-- " + e.getMessage());
         }
         
-        /* If MoPub gets location, so do we. */
-        MMSDK.setLocationEnabled( (localExtras.get("location") != null) );
+
 
         try {
             mMillennialInterstitial = InterstitialAd.createInstance(apid);


### PR DESCRIPTION
Minor changes to catch the `com.millennialmedia.MMException` at certain places in the adapter which prior to MMSDK-v6.3.0 worked fine by just catching the `IllegalStateException`.

**With MMSDK-v6.3.0 the following changes are must** 
- The `IllegalStateException` being caught at different places in the adapter needs to be replaced with `com.millennialmedia.MMException` 
  - Some additional code needs to be wrapped in `try\catch`

Changes in this pull request are minimal but must for the adapters to work with MMSDK-v6.3.0
