### PR TITLE
Use generic Context rather then Activity to support singleton approach

### DIFF
--- a/mopub-sdk/src/main/java/com/mopub/mobileads/CustomEventInterstitialAdapter.java
+++ b/mopub-sdk/src/main/java/com/mopub/mobileads/CustomEventInterstitialAdapter.java
@@ -42,7 +42,7 @@ public class CustomEventInterstitialAdapter implements CustomEventInterstitialLi
         Preconditions.checkNotNull(serverExtras);
         mHandler = new Handler();
         mMoPubInterstitial = moPubInterstitial;
-        mContext = mMoPubInterstitial.getActivity();
+        mContext = mMoPubInterstitial.getAppContext();
         mTimeout = new Runnable() {
             @Override
             public void run() {

--- a/mopub-sdk/src/main/java/com/mopub/mobileads/MoPubInterstitial.java
+++ b/mopub-sdk/src/main/java/com/mopub/mobileads/MoPubInterstitial.java
@@ -30,7 +30,7 @@ public class MoPubInterstitial implements CustomEventInterstitialAdapter.CustomE
     private MoPubInterstitialView mInterstitialView;
     private CustomEventInterstitialAdapter mCustomEventInterstitialAdapter;
     private InterstitialAdListener mInterstitialAdListener;
-    private Activity mActivity;
+    private Context mAppContext;
     private String mAdUnitId;
     private InterstitialState mCurrentInterstitialState;
     private boolean mIsDestroyed;
@@ -43,11 +43,11 @@ public class MoPubInterstitial implements CustomEventInterstitialAdapter.CustomE
         public void onInterstitialDismissed(MoPubInterstitial interstitial);
     }
 
-    public MoPubInterstitial(Activity activity, String id) {
-        mActivity = activity;
+    public MoPubInterstitial(Context ctx, String id) {
+        mAppContext = ctx.getApplicationContext();
         mAdUnitId = id;
 
-        mInterstitialView = new MoPubInterstitialView(mActivity);
+        mInterstitialView = new MoPubInterstitialView(mAppContext);
         mInterstitialView.setAdUnitId(mAdUnitId);
 
         mCurrentInterstitialState = InterstitialState.NOT_READY;
@@ -114,8 +114,8 @@ public class MoPubInterstitial implements CustomEventInterstitialAdapter.CustomE
         return mInterstitialView.getKeywords();
     }
 
-    public Activity getActivity() {
-        return mActivity;
+    public Context getAppContext() {
+        return mAppContext;
     }
 
     public Location getLocation() {


### PR DESCRIPTION
I have an app with lots of shorted lived activities, that only show ads on some exit points.  We want to be able to cache an interstitial and then call it up when we are ready to show (rather then caching ads and then throwing them away).  Converting to a generic Context rather then a specific Activity helps us to do that.