### PR TITLE
Update Requirements in README.md to include ExoPlayer r1.5.6.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Please view the [changelog](https://github.com/mopub/mopub-android-sdk/blob/mast
 - android-support-annotations.jar, r23 (**Updated in 4.4.0**)
 - android-support-v7-recyclerview.jar, r23 (**Updated in 4.4.0**)
 - MoPub Volley Library (mopub-volley-1.1.0.jar - available on JCenter) (**Updated in 3.6.0**)
+- Google ExoPlayer r1.5.6 (**Updated in 4.5.1**)
 - **Recommended** Google Play Services 7.8.0
 
 ## Upgrading from 3.2.0 and Prior


### PR DESCRIPTION
A recent upgrade I realized that I was having issues with the ExoPlayer related imports. I missed needing this package as it was not listed in the Requirements.

It looks like since at least 4.5.1 the r1.5.6 version of ExoPlayer is required.