### PR TITLE
Tapjoy SDK 11.7 update

### DIFF
--- a/extras/src/com/mopub/mobileads/TapjoyInterstitial.java
+++ b/extras/src/com/mopub/mobileads/TapjoyInterstitial.java
@@ -1,3 +1,11 @@
+// Copyright (C) 2015 by Tapjoy Inc.
+//
+// This file is part of the Tapjoy SDK.
+//
+// By using the Tapjoy SDK in your software, you agree to the terms of the Tapjoy SDK License Agreement.
+//
+// The Tapjoy SDK is bound by the Tapjoy SDK License Agreement and can be found here: https://www.tapjoy.com/sdk/license
+
 package com.mopub.mobileads;
 
 import android.content.Context;
@@ -7,42 +15,88 @@ import android.text.TextUtils;
 
 import com.mopub.common.logging.MoPubLog;
 import com.tapjoy.TJActionRequest;
+import com.tapjoy.TJConnectListener;
 import com.tapjoy.TJError;
 import com.tapjoy.TJPlacement;
 import com.tapjoy.TJPlacementListener;
+import com.tapjoy.Tapjoy;
+import com.tapjoy.TapjoyConstants;
 import com.tapjoy.TapjoyLog;
 
 import java.util.Map;
 
-// Tested with Tapjoy SDK 11.5.1
+// Tested with Tapjoy SDK 11.7.0
 public class TapjoyInterstitial extends CustomEventInterstitial implements TJPlacementListener {
     private static final String TAG = TapjoyInterstitial.class.getSimpleName();
     private static final String TJC_MOPUB_NETWORK_CONSTANT = "mopub";
-    private static final String TJC_MOPUB_ADAPTER_VERSION_NUMBER = "4.0.0";
+    private static final String TJC_MOPUB_ADAPTER_VERSION_NUMBER = "4.1.0";
+
+    // Configuration keys
+    public static final String SDK_KEY = "sdkKey";
+    public static final String DEBUG_ENABLED = "debugEnabled";
+    public static final String PLACEMENT_NAME = "name";
 
     private TJPlacement tjPlacement;
     private CustomEventInterstitialListener mInterstitialListener;
     private Handler mHandler;
+    private String placementName;
 
     static {
         TapjoyLog.i(TAG, "Class initialized with network adapter version " + TJC_MOPUB_ADAPTER_VERSION_NUMBER);
     }
 
     @Override
-    protected void loadInterstitial(Context context,
-            CustomEventInterstitialListener customEventInterstitialListener,
-            Map<String, Object> localExtras,
-            Map<String, String> serverExtras) {
+    protected void loadInterstitial(final Context context,
+                                    CustomEventInterstitialListener customEventInterstitialListener,
+                                    Map<String, Object> localExtras,
+                                    Map<String, String> serverExtras) {
         MoPubLog.d("Requesting Tapjoy interstitial");
 
         mInterstitialListener = customEventInterstitialListener;
         mHandler = new Handler(Looper.getMainLooper());
 
-        String name = serverExtras.get("name");
-        if (TextUtils.isEmpty(name)) {
+        placementName = serverExtras.get(PLACEMENT_NAME);
+        if (TextUtils.isEmpty(placementName)) {
             MoPubLog.d("Tapjoy interstitial loaded with empty 'name' field. Request will fail.");
         }
-        tjPlacement = new TJPlacement(context, name, this);
+
+        boolean canRequestPlacement = true;
+        if (!Tapjoy.isConnected()) {
+            // Check if configuration data is available
+            boolean enableDebug = Boolean.valueOf(serverExtras.get(DEBUG_ENABLED));
+            Tapjoy.setDebugEnabled(enableDebug);
+
+            String sdkKey = serverExtras.get(SDK_KEY);
+            if (!TextUtils.isEmpty(sdkKey)) {
+                MoPubLog.d("Connecting to Tapjoy via MoPub dashboard settings...");
+                Tapjoy.connect(context, sdkKey, null, new TJConnectListener() {
+                    @Override
+                    public void onConnectSuccess() {
+                        MoPubLog.d("Tapjoy connected successfully");
+                        createPlacement(context);
+                    }
+
+                    @Override
+                    public void onConnectFailure() {
+                        MoPubLog.d("Tapjoy connect failed");
+                    }
+                });
+
+                // If sdkKey is present via MoPub dashboard, we only want to request placement
+                // after auto-connect succeeds
+                canRequestPlacement = false;
+            } else {
+                MoPubLog.d("Tapjoy interstitial is initialized with empty 'sdkKey'. You must call Tapjoy.connect()");
+            }
+        }
+
+        if (canRequestPlacement) {
+            createPlacement(context);
+        }
+    }
+
+    private void createPlacement(Context context) {
+        tjPlacement = new TJPlacement(context, placementName, this);
         tjPlacement.setMediationName(TJC_MOPUB_NETWORK_CONSTANT);
         tjPlacement.setAdapterVersion(TJC_MOPUB_ADAPTER_VERSION_NUMBER);
         tjPlacement.requestContent();
@@ -119,12 +173,12 @@ public class TapjoyInterstitial extends CustomEventInterstitial implements TJPla
 
     @Override
     public void onPurchaseRequest(TJPlacement placement, TJActionRequest request,
-            String productId) {
+                                  String productId) {
     }
 
     @Override
     public void onRewardRequest(TJPlacement placement, TJActionRequest request, String itemId,
-            int quantity) {
+                                int quantity) {
     }
 
 }

--- a/extras/src/com/mopub/mobileads/TapjoyRewardedVideo.java
+++ b/extras/src/com/mopub/mobileads/TapjoyRewardedVideo.java
@@ -16,21 +16,29 @@ import com.tapjoy.TJPlacement;
 import com.tapjoy.TJPlacementListener;
 import com.tapjoy.TJVideoListener;
 import com.tapjoy.Tapjoy;
+import com.tapjoy.TapjoyConstants;
 import com.tapjoy.TapjoyLog;
 
 import java.util.Hashtable;
 import java.util.Map;
 
-// Tested with Tapjoy SDK 11.5.1
+// Tested with Tapjoy SDK 11.7.0
 public class TapjoyRewardedVideo extends CustomEventRewardedVideo {
     private static final String TAG = TapjoyRewardedVideo.class.getSimpleName();
     private static final String TJC_MOPUB_NETWORK_CONSTANT = "mopub";
-    private static final String TJC_MOPUB_ADAPTER_VERSION_NUMBER = "4.0.0";
+    private static final String TJC_MOPUB_ADAPTER_VERSION_NUMBER = "4.1.0";
     private static final String TAPJOY_AD_NETWORK_CONSTANT = "tapjoy_id";
 
+    // Configuration keys
+    public static final String SDK_KEY = "sdkKey";
+    public static final String DEBUG_ENABLED = "debugEnabled";
+    public static final String PLACEMENT_NAME = "name";
+
     private String sdkKey;
+    private String placementName;
     private Hashtable<String, Object> connectFlags;
     private TJPlacement tjPlacement;
+    private boolean isAutoConnect = false;
     private static TapjoyRewardedVideoListener sTapjoyListener = new TapjoyRewardedVideoListener();
 
     static {
@@ -58,29 +66,37 @@ public class TapjoyRewardedVideo extends CustomEventRewardedVideo {
 
     @Override
     protected boolean checkAndInitializeSdk(@NonNull Activity launcherActivity,
-            @NonNull Map<String, Object> localExtras,
-            @NonNull Map<String, String> serverExtras)
+                                            @NonNull Map<String, Object> localExtras,
+                                            @NonNull Map<String, String> serverExtras)
             throws Exception {
+
+        placementName = serverExtras.get(PLACEMENT_NAME);
+        if (TextUtils.isEmpty(placementName)) {
+            MoPubLog.d("Tapjoy rewarded video loaded with empty 'name' field. Request will fail.");
+        }
 
         if (!Tapjoy.isConnected()) {
             if (checkAndInitMediationSettings()) {
-                MoPubLog.d("Request to connect to Tapjoy");
+                MoPubLog.d("Connecting to Tapjoy via MoPub mediation settings...");
+                connectToTapjoy(launcherActivity);
 
-                Tapjoy.connect(launcherActivity, sdkKey, connectFlags, new TJConnectListener() {
-                    @Override
-                    public void onConnectSuccess() {
-                        MoPubLog.d("Tapjoy connected successfully");
-                    }
-
-                    @Override
-                    public void onConnectFailure() {
-                        MoPubLog.e("Tapjoy connect failed");
-                    }
-                });
-
+                isAutoConnect = true;
                 return true;
             } else {
-                MoPubLog.d("Cannot connect to Tapjoy -- missing 'sdkkey' declaration via TapjoyMediationSettings");
+                boolean enableDebug = Boolean.valueOf(serverExtras.get(DEBUG_ENABLED));
+                Tapjoy.setDebugEnabled(enableDebug);
+
+                sdkKey = serverExtras.get(SDK_KEY);
+                if (!TextUtils.isEmpty(sdkKey)) {
+                    MoPubLog.d("Connecting to Tapjoy via MoPub dashboard settings...");
+                    connectToTapjoy(launcherActivity);
+
+                    isAutoConnect = true;
+                    return true;
+                } else {
+                    MoPubLog.d("Tapjoy rewarded video is initialized with empty 'sdkKey'. You must call Tapjoy.connect()");
+                    isAutoConnect = false;
+                }
             }
         }
 
@@ -89,19 +105,41 @@ public class TapjoyRewardedVideo extends CustomEventRewardedVideo {
 
     @Override
     protected void loadWithSdkInitialized(@NonNull Activity activity,
-            @NonNull Map<String, Object> localExtras,
-            @NonNull Map<String, String> serverExtras)
+                                          @NonNull Map<String, Object> localExtras,
+                                          @NonNull Map<String, String> serverExtras)
             throws Exception {
         MoPubLog.d("Requesting Tapjoy rewarded video");
+        createPlacement(activity);
+    }
 
-        String name = serverExtras.get("name");
-        if (TextUtils.isEmpty(name)) {
-            MoPubLog.d("Tapjoy interstitial loaded with empty 'name' field. Request will fail.");
+    private void connectToTapjoy(final Activity launcherActivity) {
+        Tapjoy.connect(launcherActivity, sdkKey, connectFlags, new TJConnectListener() {
+            @Override
+            public void onConnectSuccess() {
+                MoPubLog.d("Tapjoy connected successfully");
+                createPlacement(launcherActivity);
+            }
+
+            @Override
+            public void onConnectFailure() {
+                MoPubLog.d("Tapjoy connect failed");
+            }
+        });
+    }
+
+    private void createPlacement(Activity activity) {
+        if (!TextUtils.isEmpty(placementName)) {
+            if (isAutoConnect && !Tapjoy.isConnected()) {
+                // If adapter is making the Tapjoy.connect() call on behalf of the pub, wait for it to
+                // succeed before making a placement request.
+                return;
+            }
+
+            tjPlacement = new TJPlacement(activity, placementName, sTapjoyListener);
+            tjPlacement.setMediationName(TJC_MOPUB_NETWORK_CONSTANT);
+            tjPlacement.setAdapterVersion(TJC_MOPUB_ADAPTER_VERSION_NUMBER);
+            tjPlacement.requestContent();
         }
-        tjPlacement = new TJPlacement(activity, name, sTapjoyListener);
-        tjPlacement.setMediationName(TJC_MOPUB_NETWORK_CONSTANT);
-        tjPlacement.setAdapterVersion(TJC_MOPUB_ADAPTER_VERSION_NUMBER);
-        tjPlacement.requestContent();
     }
 
     @Override
@@ -117,19 +155,19 @@ public class TapjoyRewardedVideo extends CustomEventRewardedVideo {
         } else {
             MoPubLog.d("Failed to show Tapjoy rewarded video.");
         }
-
     }
 
     private boolean checkAndInitMediationSettings() {
-        MoPubLog.d("Initializing Tapjoy mediation settings");
-
         final TapjoyMediationSettings globalMediationSettings =
-                MoPubRewardedVideoManager.getGlobalMediationSettings(TapjoyMediationSettings.class);
+            MoPubRewardedVideoManager.getGlobalMediationSettings(TapjoyMediationSettings.class);
 
         if (globalMediationSettings != null) {
+            MoPubLog.d("Initializing Tapjoy mediation settings");
+
             if (!TextUtils.isEmpty(globalMediationSettings.getSdkKey())) {
                 sdkKey = globalMediationSettings.getSdkKey();
             } else {
+                MoPubLog.d("Cannot initialize Tapjoy -- 'sdkkey' is empty");
                 return false;
             }
 
@@ -146,7 +184,7 @@ public class TapjoyRewardedVideo extends CustomEventRewardedVideo {
     private static class TapjoyRewardedVideoListener implements TJPlacementListener, CustomEventRewardedVideoListener, TJVideoListener {
         @Override
         public void onRequestSuccess(TJPlacement placement) {
-            if (!placement.isContentAvailable()){
+            if (!placement.isContentAvailable()) {
                 MoPubLog.d("No Tapjoy rewarded videos available");
                 MoPubRewardedVideoManager.onRewardedVideoLoadFailure(TapjoyRewardedVideo.class, TAPJOY_AD_NETWORK_CONSTANT, MoPubErrorCode.NETWORK_NO_FILL);
             }
@@ -180,12 +218,12 @@ public class TapjoyRewardedVideo extends CustomEventRewardedVideo {
 
         @Override
         public void onPurchaseRequest(TJPlacement placement, TJActionRequest request,
-                String productId) {
+                                      String productId) {
         }
 
         @Override
         public void onRewardRequest(TJPlacement placement, TJActionRequest request, String itemId,
-                int quantity) {
+                                    int quantity) {
         }
 
         @Override


### PR DESCRIPTION
Update for Tapjoy 11.7 SDK:

- Enable Tapjoy auto-connect when `sdkKey` is defined in the MoPub dashboard via the `CUSTOM EVENT CLASS DATA` box. For example:
```
{
"sdkKey":"enter_publisher_api_key_here",
 "name": "video_unit",
 "debugEnabled":"true"
}
```
