### PR TITLE
Update Streams.java so Close Doesn't Crash

### DIFF
--- a/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/common/util/Streams.java
+++ b/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/common/util/Streams.java
@@ -60,6 +60,8 @@ public class Streams {
 
         try {
             stream.close();
+        } catch (java.lang.IllegalStateException e) {
+            // Unable to close the stream
         } catch (IOException e) {
             // Unable to close the stream
         }


### PR DESCRIPTION
An IllegalStateException is possible from closing a stream, and should be (must be) ignored in this case.