### PR TITLE
Update UrlResolutionTask for IllegalStateException

### DIFF
--- a/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/common/UrlResolutionTask.java
+++ b/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/common/UrlResolutionTask.java
@@ -84,6 +84,10 @@ public class UrlResolutionTask extends AsyncTask<String, Void, String> {
             httpUrlConnection.setInstanceFollowRedirects(false);
 
             return resolveRedirectLocation(urlString, httpUrlConnection);
+        } catch (java.lang.IllegalStateException e) {
+            //java.lang.IllegalStateException possible from com.android.okhttp.internal.huc.HttpURLConnectionImpl.getResponseCode -> com.android.okhttp.internal.DiskLruCache.checkNotClosed
+            //Throw a new IOException like resolveRedirectLocation would for a similar IO error
+            throw new IOException("Unable to resolve URL due to IllegalStateException", e);
         } finally {
             if (httpUrlConnection != null) {
                 httpUrlConnection.disconnect();


### PR DESCRIPTION
UrlResolutionTask can encounter an IllegalStateException on resolving redirect location (resolveRedirectLocation) at httpUrlConnection.getResponseCode(). This is essentially the same as an IOException in this case, and should be thrown as such so that the doInBackground proceeds correctly without crashing the app.