### PR TITLE
Make MoPubStaticNativeAd public

### DIFF
--- a/mopub-sdk/mopub-sdk-native-static/src/main/java/com/mopub/nativeads/MoPubCustomEventNative.java
+++ b/mopub-sdk/mopub-sdk-native-static/src/main/java/com/mopub/nativeads/MoPubCustomEventNative.java
@@ -53,7 +53,7 @@ public class MoPubCustomEventNative extends CustomEventNative {
         }
     }
 
-    static class MoPubStaticNativeAd extends StaticNativeAd {
+    public static class MoPubStaticNativeAd extends StaticNativeAd {
         enum Parameter {
             IMPRESSION_TRACKER("imptracker", true),
             CLICK_TRACKER("clktracker", true),


### PR DESCRIPTION
* Helps to find out what concrete implementation returns NativeAd.getBaseNativeAd(). MoPubVideoNativeAd is public too.