### PR TITLE
Delete removed methods from Chartboost adapter

### DIFF
--- a/extras/src/com/mopub/mobileads/ChartboostInterstitial.java
+++ b/extras/src/com/mopub/mobileads/ChartboostInterstitial.java
@@ -14,7 +14,7 @@ import java.util.Map;
 /**
  * A custom event for showing Chartboost interstitial ads.
  *
- * Download the latest Chartboost SDK at  chartboost.com/android
+ * Certified with Chartboost 6.5.1
  */
 class ChartboostInterstitial extends CustomEventInterstitial {
 

--- a/extras/src/com/mopub/mobileads/ChartboostInterstitial.java
+++ b/extras/src/com/mopub/mobileads/ChartboostInterstitial.java
@@ -14,7 +14,7 @@ import java.util.Map;
 /**
  * A custom event for showing Chartboost interstitial ads.
  *
- * Certified with Chartboost 6.4.1
+ * Download the latest Chartboost SDK at  chartboost.com/android
  */
 class ChartboostInterstitial extends CustomEventInterstitial {
 

--- a/extras/src/com/mopub/mobileads/ChartboostRewardedVideo.java
+++ b/extras/src/com/mopub/mobileads/ChartboostRewardedVideo.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * A custom event for showing Chartboost rewarded videos.
  *
- * Certified with Chartboost 6.4.1
+ * Download the latest Chartboost SDK at  chartboost.com/android
  */
 public class ChartboostRewardedVideo extends CustomEventRewardedVideo {
     @NonNull private static final LifecycleListener sLifecycleListener =

--- a/extras/src/com/mopub/mobileads/ChartboostRewardedVideo.java
+++ b/extras/src/com/mopub/mobileads/ChartboostRewardedVideo.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * A custom event for showing Chartboost rewarded videos.
  *
- * Download the latest Chartboost SDK at  chartboost.com/android
+ * Certified with Chartboost 6.5.1
  */
 public class ChartboostRewardedVideo extends CustomEventRewardedVideo {
     @NonNull private static final LifecycleListener sLifecycleListener =

--- a/extras/src/com/mopub/mobileads/ChartboostShared.java
+++ b/extras/src/com/mopub/mobileads/ChartboostShared.java
@@ -75,7 +75,6 @@ public class ChartboostShared {
 
         // Perform all the common SDK initialization steps including startAppWithId
         Chartboost.startWithAppId(launcherActivity, mAppId, mAppSignature);
-        Chartboost.setImpressionsUseActivities(false);
         Chartboost.setMediation(Chartboost.CBMediation.CBMediationMoPub, MoPub.SDK_VERSION);
         Chartboost.setDelegate(sDelegate);
         Chartboost.setShouldRequestInterstitialsInFirstSession(true);

--- a/extras/src/com/mopub/mobileads/ChartboostShared.java
+++ b/extras/src/com/mopub/mobileads/ChartboostShared.java
@@ -27,7 +27,7 @@ import static com.mopub.mobileads.MoPubErrorCode.VIDEO_DOWNLOAD_ERROR;
 /**
  * Shared infrastructure for initializing the Chartboost SDK when mediated by MoPub
  *
- * Certified with Chartboost 6.4.1
+ * Download the latest Chartboost SDK at  chartboost.com/android
  */
 public class ChartboostShared {
     private static volatile ChartboostSingletonDelegate sDelegate = new ChartboostSingletonDelegate();

--- a/extras/src/com/mopub/mobileads/ChartboostShared.java
+++ b/extras/src/com/mopub/mobileads/ChartboostShared.java
@@ -27,7 +27,7 @@ import static com.mopub.mobileads.MoPubErrorCode.VIDEO_DOWNLOAD_ERROR;
 /**
  * Shared infrastructure for initializing the Chartboost SDK when mediated by MoPub
  *
- * Download the latest Chartboost SDK at  chartboost.com/android
+ * Certified with Chartboost 6.5.1
  */
 public class ChartboostShared {
     private static volatile ChartboostSingletonDelegate sDelegate = new ChartboostSingletonDelegate();


### PR DESCRIPTION
The method `setImpressionsUseActivities()` is no longer available in the Chartboost SDK 6.5.1. It was deprecated before, but now it's deleted from the API. 

Since the method was deprecated and no-op, this removal should not cause any changes in the behaviour of the integration.
