### PR TITLE
MRAID wrong landscape orientation bug fix

### DIFF
--- a/mopub-sample/AndroidManifest.xml
+++ b/mopub-sample/AndroidManifest.xml
@@ -29,7 +29,7 @@
         <activity android:name="com.mopub.common.MoPubBrowser"
                 android:configChanges="keyboardHidden|orientation|screenSize"/>
         <activity android:name="com.mopub.mobileads.MraidVideoPlayerActivity"
-                android:configChanges="keyboardHidden|orientation|screenSize"/>
+                android:configChanges="keyboardHidden|orientation|screenSize" android:screenOrientation="sensorLandscape" />
 
         <meta-data android:name="com.google.android.gms.version"
                    android:value="@integer/google_play_services_version" />

--- a/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/mobileads/VastVideoViewController.java
+++ b/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/mobileads/VastVideoViewController.java
@@ -34,6 +34,7 @@ import java.io.Serializable;
 import java.util.Map;
 
 import static android.content.pm.ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE;
+import static android.content.pm.ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE;
 import static android.content.pm.ActivityInfo.SCREEN_ORIENTATION_PORTRAIT;
 import static com.mopub.common.MoPubBrowser.MOPUB_BROWSER_REQUEST_CODE;
 import static com.mopub.mobileads.VastXmlManagerAggregator.ADS_BY_AD_SLOT_ID;
@@ -164,7 +165,7 @@ public class VastVideoViewController extends BaseVideoViewController {
 
         // Companion ad view, set to invisible initially to have it be drawn to calculate size
         mLandscapeCompanionAdView = createCompanionAdView(activity,
-                mVastVideoConfig.getVastCompanionAd(Configuration.ORIENTATION_LANDSCAPE),
+                mVastVideoConfig.getVastCompanionAd(Configuration.SCREEN_ORIENTATION_SENSOR_LANDSCAPE),
                 View.INVISIBLE);
         mPortraitCompanionAdView = createCompanionAdView(activity,
                 mVastVideoConfig.getVastCompanionAd(Configuration.ORIENTATION_PORTRAIT),


### PR DESCRIPTION
Mopub MRAID ads do not respect sensor landscape, but force user to
rotate their device.