### PR TITLE
Updating AdColony adapters for the 3.0.5 SDK

### DIFF
--- a/extras/src/com/mopub/mobileads/AdColonyInterstitial.java
+++ b/extras/src/com/mopub/mobileads/AdColonyInterstitial.java
@@ -5,26 +5,25 @@ import android.content.Context;
 import android.os.Handler;
 import android.util.Log;
 
-import com.jirbo.adcolony.AdColony;
-import com.jirbo.adcolony.AdColonyAd;
-import com.jirbo.adcolony.AdColonyAdListener;
-import com.jirbo.adcolony.AdColonyVideoAd;
+import com.adcolony.sdk.AdColony;
+import com.adcolony.sdk.AdColonyAppOptions;
+import com.adcolony.sdk.AdColonyInterstitialListener;
+import com.adcolony.sdk.AdColonyZone;
 import com.mopub.common.util.Json;
 
 import java.util.Map;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 /*
- * Tested with AdColony SDK 2.0.3.
+ * Tested with AdColony SDK 3.0.5.
  */
-public class AdColonyInterstitial extends CustomEventInterstitial implements AdColonyAdListener {
+public class AdColonyInterstitial extends CustomEventInterstitial {
+    private static final String TAG = "AdColonyInterstitial";
     /*
      * We recommend passing the AdColony client options, app ID, all zone IDs, and current zone ID
      * in the serverExtras Map by specifying Custom Event Data in MoPub's web interface.
      *
      * Please see AdColony's documentation for more information:
-     * https://github.com/AdColony/AdColony-Android-SDK/wiki/API-Details#configure-activity-activity-string-client_options-string-app_id-string-zone_ids-
+     * https://github.com/AdColony/AdColony-Android-SDK-3
      */
     private static final String DEFAULT_CLIENT_OPTIONS = "version=YOUR_APP_VERSION_HERE,store:google";
     private static final String DEFAULT_APP_ID = "YOUR_AD_COLONY_APP_ID_HERE";
@@ -39,16 +38,12 @@ public class AdColonyInterstitial extends CustomEventInterstitial implements AdC
     public static final String ALL_ZONE_IDS_KEY = "allZoneIds";
     public static final String ZONE_ID_KEY = "zoneId";
 
-    private static boolean isAdColonyConfigured = false;
-
     private CustomEventInterstitialListener mCustomEventInterstitialListener;
+    private AdColonyInterstitialListener mAdColonyInterstitialListener;
     private final Handler mHandler;
-    private AdColonyVideoAd mAdColonyVideoAd;
-    private final ScheduledThreadPoolExecutor mScheduledThreadPoolExecutor;
-    private boolean mIsLoading;
+    private com.adcolony.sdk.AdColonyInterstitial mAdColonyInterstitial;
 
     public AdColonyInterstitial() {
-        mScheduledThreadPoolExecutor = new ScheduledThreadPoolExecutor(1);
         mHandler = new Handler();
     }
 
@@ -76,34 +71,144 @@ public class AdColonyInterstitial extends CustomEventInterstitial implements AdC
             zoneId = serverExtras.get(ZONE_ID_KEY);
         }
 
-        if (!isAdColonyConfigured) {
-            AdColony.configure((Activity)context, clientOptions, appId, allZoneIds);
-            isAdColonyConfigured = true;
+        mAdColonyInterstitialListener = getAdColonyInterstitialListener();
+        if (!isAdColonyConfigured()) {
+            AdColony.configure((Activity) context, getAppOptions(clientOptions), appId, allZoneIds);
         }
 
-        mAdColonyVideoAd = new AdColonyVideoAd(zoneId);
-        mAdColonyVideoAd.withListener(this);
-
-        scheduleOnInterstitialLoaded();
+        AdColony.requestInterstitial(zoneId, mAdColonyInterstitialListener);
     }
 
     @Override
     protected void showInterstitial() {
-        if (mAdColonyVideoAd.isReady()) {
-            mAdColonyVideoAd.show();
+        if (mAdColonyInterstitial == null || mAdColonyInterstitial.isExpired()) {
+            Log.e(TAG, "AdColony interstitial ad is null or has expired");
+            mHandler.post(new Runnable() {
+                @Override
+                public void run() {
+                    mCustomEventInterstitialListener.onInterstitialFailed(MoPubErrorCode.VIDEO_PLAYBACK_ERROR);
+                }
+            });
         } else {
-            Log.d("MoPub", "Tried to show a AdColony interstitial ad before it finished loading. Please try again.");
+            mAdColonyInterstitial.show();
         }
     }
 
     @Override
     protected void onInvalidate() {
-        if (mAdColonyVideoAd != null) {
-            mAdColonyVideoAd.withListener(null);
+        if (mAdColonyInterstitial != null) {
+            mAdColonyInterstitialListener = null;
+            mAdColonyInterstitial.setListener(null);
+            mAdColonyInterstitial.destroy();
+            mAdColonyInterstitial = null;
+        }
+    }
+
+    private AdColonyAppOptions getAppOptions(String clientOptions) {
+        if (clientOptions == null || clientOptions.isEmpty()) {
+            return null;
+        }
+        AdColonyAppOptions adColonyAppOptions = new AdColonyAppOptions();
+        String[] allOptions = clientOptions.split(",");
+        for (String option : allOptions) {
+            String optionNameAndValue[] = option.split(":");
+            if (optionNameAndValue.length == 2) {
+                switch (optionNameAndValue[0]) {
+                    case "store":
+                        adColonyAppOptions.setOriginStore(optionNameAndValue[1]);
+                        break;
+                    case "version":
+                        adColonyAppOptions.setAppVersion(optionNameAndValue[1]);
+                        break;
+                    default:
+                        Log.e(TAG, "AdColony client options in wrong format - please check your MoPub dashboard");
+                        return null;
+                }
+            } else {
+                Log.e(TAG, "AdColony client options in wrong format - please check your MoPub dashboard");
+                return null;
+            }
         }
 
-        mScheduledThreadPoolExecutor.shutdownNow();
-        mIsLoading = false;
+        return adColonyAppOptions;
+    }
+
+    private boolean isAdColonyConfigured() {
+        return !AdColony.getSDKVersion().isEmpty();
+    }
+
+    private AdColonyInterstitialListener getAdColonyInterstitialListener() {
+        if (mAdColonyInterstitialListener != null) {
+            return mAdColonyInterstitialListener;
+        } else {
+            return new AdColonyInterstitialListener() {
+                @Override
+                public void onRequestFilled(com.adcolony.sdk.AdColonyInterstitial adColonyInterstitial) {
+                    mAdColonyInterstitial = adColonyInterstitial;
+                    Log.d(TAG, "AdColony interstitial ad has been successfully loaded.");
+                    mHandler.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            mCustomEventInterstitialListener.onInterstitialLoaded();
+                        }
+                    });
+                }
+
+                @Override
+                public void onRequestNotFilled(AdColonyZone zone) {
+                    Log.d(TAG, "AdColony interstitial ad has no fill.");
+                    mHandler.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            mCustomEventInterstitialListener.onInterstitialFailed(MoPubErrorCode.NETWORK_NO_FILL);
+                        }
+                    });
+                }
+
+                @Override
+                public void onClosed(com.adcolony.sdk.AdColonyInterstitial ad) {
+                    Log.d(TAG, "AdColony interstitial ad has been dismissed.");
+                    mHandler.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            mCustomEventInterstitialListener.onInterstitialDismissed();
+                        }
+                    });
+                }
+
+                @Override
+                public void onOpened(com.adcolony.sdk.AdColonyInterstitial ad) {
+                    Log.d(TAG, "AdColony interstitial ad shown: " + ad.getZoneID());
+                    mHandler.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            mCustomEventInterstitialListener.onInterstitialShown();
+                        }
+                    });
+                }
+
+                @Override
+                public void onExpiring(com.adcolony.sdk.AdColonyInterstitial ad) {
+                    Log.d(TAG, "AdColony interstitial ad is expiring; requesting new ad");
+                    AdColony.requestInterstitial(ad.getZoneID(), mAdColonyInterstitialListener);
+                }
+
+                @Override
+                public void onLeftApplication(com.adcolony.sdk.AdColonyInterstitial ad) {
+                    mHandler.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            mCustomEventInterstitialListener.onLeaveApplication();
+                        }
+                    });
+                }
+
+                @Override
+                public void onClicked(com.adcolony.sdk.AdColonyInterstitial ad) {
+                    mCustomEventInterstitialListener.onInterstitialClicked();
+                }
+            };
+        }
     }
 
     private boolean extrasAreValid(Map<String, String> extras) {
@@ -124,63 +229,10 @@ public class AdColonyInterstitial extends CustomEventInterstitial implements AdC
         return result;
     }
 
-    private void scheduleOnInterstitialLoaded() {
-        Runnable runnable = new Runnable() {
-            @Override
-            public void run() {
-                if (mAdColonyVideoAd.isReady()) {
-                    Log.d("MoPub", "AdColony interstitial ad successfully loaded.");
-                    mIsLoading = false;
-                    mScheduledThreadPoolExecutor.shutdownNow();
-                    mHandler.post(new Runnable() {
-                        @Override
-                        public void run() {
-                            mCustomEventInterstitialListener.onInterstitialLoaded();
-                        }
-                    });
-                }
-            }
-        };
-
-        if (!mIsLoading) {
-            mScheduledThreadPoolExecutor.scheduleAtFixedRate(runnable, 1, 1, TimeUnit.SECONDS);
-            mIsLoading = true;
-        }
-    }
-
-    /*
-     * AdColonyAdListener implementation
-     */
-
-    @Override
-    public void onAdColonyAdStarted(AdColonyAd adColonyAd) {
-        Log.d("MoPub", "AdColony interstitial ad shown.");
-        mHandler.post(new Runnable() {
-            @Override
-            public void run() {
-                mCustomEventInterstitialListener.onInterstitialShown();
-            }
-        });
-    }
-
-    @Override
-    public void onAdColonyAdAttemptFinished(AdColonyAd adColonyAd) {
-        Log.d("MoPub", "AdColony interstitial ad dismissed.");
-        mHandler.post(new Runnable() {
-            @Override
-            public void run() {
-                mCustomEventInterstitialListener.onInterstitialDismissed();
-            }
-        });
-    }
-
-    @Deprecated // for testing
-    ScheduledThreadPoolExecutor getScheduledThreadPoolExecutor() {
-        return mScheduledThreadPoolExecutor;
-    }
-
-    @Deprecated // for testing
-    void resetAdColonyConfigured() {
-        isAdColonyConfigured = false;
+    @Deprecated
+    // For testing
+    public static String getAdUnitId(MoPubInterstitial interstitial) {
+        return interstitial.getMoPubInterstitialView().getAdUnitId();
     }
 }
+

--- a/extras/src/com/mopub/mobileads/AdColonyRewardedVideo.java
+++ b/extras/src/com/mopub/mobileads/AdColonyRewardedVideo.java
@@ -4,39 +4,42 @@ import android.app.Activity;
 import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.util.Log;
 
-import com.jirbo.adcolony.AdColony;
-import com.jirbo.adcolony.AdColonyAd;
-import com.jirbo.adcolony.AdColonyAdListener;
-import com.jirbo.adcolony.AdColonyV4VCAd;
-import com.jirbo.adcolony.AdColonyV4VCListener;
-import com.jirbo.adcolony.AdColonyV4VCReward;
+import com.adcolony.sdk.AdColony;
+import com.adcolony.sdk.AdColonyAdOptions;
+import com.adcolony.sdk.AdColonyAppOptions;
+import com.adcolony.sdk.AdColonyInterstitial;
+import com.adcolony.sdk.AdColonyInterstitialListener;
+import com.adcolony.sdk.AdColonyReward;
+import com.adcolony.sdk.AdColonyRewardListener;
+import com.adcolony.sdk.AdColonyZone;
+
 import com.mopub.common.BaseLifecycleListener;
 import com.mopub.common.DataKeys;
 import com.mopub.common.LifecycleListener;
 import com.mopub.common.MediationSettings;
 import com.mopub.common.MoPubReward;
-import com.mopub.common.logging.MoPubLog;
 import com.mopub.common.util.Json;
 
 import java.util.Map;
 import java.util.WeakHashMap;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 /**
  * A custom event for showing AdColony rewarded videos.
- *
- * Certified with AdColony 2.0.3
+ * <p>
+ * Certified with AdColony 3.0.5
  */
 public class AdColonyRewardedVideo extends CustomEventRewardedVideo {
+    private static final String TAG = "AdColonyRewardedVideo";
     /*
      * We recommend passing the AdColony client options, app ID, all zone IDs, and current zone ID
      * in the serverExtras Map by specifying Custom Event Data in MoPub's web interface.
      *
      * Please see AdColony's documentation for more information:
-     * https://github.com/AdColony/AdColony-Android-SDK/wiki/API-Details#configure-activity-activity-string-client_options-string-app_id-string-zone_ids-
+     * https://github.com/AdColony/AdColony-Android-SDK-3
      */
     private static final String DEFAULT_CLIENT_OPTIONS = "version=YOUR_APP_VERSION_HERE,store:google";
     private static final String DEFAULT_APP_ID = "YOUR_AD_COLONY_APP_ID_HERE";
@@ -52,31 +55,23 @@ public class AdColonyRewardedVideo extends CustomEventRewardedVideo {
     public static final String ZONE_ID_KEY = "zoneId";
 
     private static boolean sInitialized = false;
-    private static LifecycleListener sLifecycleListener = new BaseLifecycleListener() {
-        @Override
-        public void onPause(@NonNull final Activity activity) {
-            super.onPause(activity);
-            AdColony.pause();
-        }
+    private static LifecycleListener sLifecycleListener = new BaseLifecycleListener();
 
-        @Override
-        public void onResume(@NonNull final Activity activity) {
-            super.onResume(activity);
-            AdColony.resume(activity);
-        }
-    };
-    private static AdColonyListener sAdColonyListener = new AdColonyListener();
-    private static WeakHashMap<AdColonyAd, String> sAdToZoneIdMap = new WeakHashMap<AdColonyAd, String>();
-
-    private AdColonyV4VCAd mAd;
+    AdColonyInterstitial mAd;
     private String mZoneId;
-    @Nullable private String mAdUnitId;
+    private AdColonyListener mAdColonyListener;
+    private AdColonyAdOptions mAdColonyAdOptions = new AdColonyAdOptions();
+    private AdColonyAppOptions mAdColonyAppOptions = new AdColonyAppOptions();
+    private static WeakHashMap<String, AdColonyInterstitial> sZoneIdToAdMap = new WeakHashMap<>();
+
+
+    @Nullable
+    private String mAdUnitId;
     private boolean mIsLoading = false;
 
     // For waiting and notifying the SDK:
     private final Handler mHandler;
     private final ScheduledThreadPoolExecutor mScheduledThreadPoolExecutor;
-    private ScheduledFuture<?> mFuture;
 
     public AdColonyRewardedVideo() {
         mScheduledThreadPoolExecutor = new ScheduledThreadPoolExecutor(1);
@@ -86,7 +81,7 @@ public class AdColonyRewardedVideo extends CustomEventRewardedVideo {
     @Nullable
     @Override
     public CustomEventRewardedVideoListener getVideoListenerForSdk() {
-        return sAdColonyListener;
+        return mAdColonyListener;
     }
 
     @Nullable
@@ -104,12 +99,19 @@ public class AdColonyRewardedVideo extends CustomEventRewardedVideo {
     @Override
     protected void onInvalidate() {
         mScheduledThreadPoolExecutor.shutdownNow();
+        AdColonyInterstitial ad = sZoneIdToAdMap.get(mZoneId);
+        if (ad != null) {
+            ad.setListener(null);
+            ad.destroy();
+            sZoneIdToAdMap.remove(mZoneId);
+            Log.d(TAG, "AdColony rewarded video destroyed");
+        }
     }
 
     @Override
     public boolean checkAndInitializeSdk(@NonNull final Activity launcherActivity,
-            @NonNull final Map<String, Object> localExtras,
-            @NonNull final Map<String, String> serverExtras) throws Exception {
+                                         @NonNull final Map<String, Object> localExtras,
+                                         @NonNull final Map<String, String> serverExtras) throws Exception {
         synchronized (AdColonyRewardedVideo.class) {
             if (sInitialized) {
                 return false;
@@ -127,8 +129,12 @@ public class AdColonyRewardedVideo extends CustomEventRewardedVideo {
             }
 
             setUpGlobalSettings();
-            AdColony.configure(launcherActivity, adColonyClientOptions, adColonyAppId, adColonyAllZoneIds);
-            AdColony.addV4VCListener(sAdColonyListener);
+            setAppOptions(adColonyClientOptions);
+
+            if (!isAdColonyConfigured()) {
+                AdColony.configure(launcherActivity, mAdColonyAppOptions, adColonyAppId, adColonyAllZoneIds);
+            }
+
             sInitialized = true;
             return true;
         }
@@ -136,8 +142,8 @@ public class AdColonyRewardedVideo extends CustomEventRewardedVideo {
 
     @Override
     protected void loadWithSdkInitialized(@NonNull final Activity activity,
-            @NonNull final Map<String, Object> localExtras,
-            @NonNull final Map<String, String> serverExtras) throws Exception {
+                                          @NonNull final Map<String, Object> localExtras,
+                                          @NonNull final Map<String, String> serverExtras) throws Exception {
 
         mZoneId = DEFAULT_ZONE_ID;
         if (extrasAreValid(serverExtras)) {
@@ -148,24 +154,65 @@ public class AdColonyRewardedVideo extends CustomEventRewardedVideo {
             mAdUnitId = (String) adUnitObject;
         }
 
-        mAd = new AdColonyV4VCAd(mZoneId).withListener(sAdColonyListener);
-        sAdToZoneIdMap.put(mAd, mZoneId);
+        sZoneIdToAdMap.put(mZoneId, null);
+        setUpAdOptions();
+        mAdColonyListener = new AdColonyListener(mAdColonyAdOptions);
+        AdColony.setRewardListener(mAdColonyListener);
+        AdColony.requestInterstitial(mZoneId, mAdColonyListener, mAdColonyAdOptions);
         scheduleOnVideoReady();
+    }
+
+    private void setUpAdOptions() {
+        mAdColonyAdOptions.enableConfirmationDialog(getConfirmationDialogFromSettings());
+        mAdColonyAdOptions.enableResultsDialog(getResultsDialogFromSettings());
+    }
+
+    private void setAppOptions(String clientOptions) {
+        if (clientOptions == null || clientOptions.isEmpty()) {
+            Log.d(TAG, "AdColony client options are not configured on the MoPub dashboard");
+            return;
+        }
+
+        String[] allOptions = clientOptions.split(",");
+        for (String option : allOptions) {
+            String optionNameAndValue[] = option.split(":");
+            if (optionNameAndValue.length == 2) {
+                switch (optionNameAndValue[0]) {
+                    case "store":
+                        mAdColonyAppOptions.setOriginStore(optionNameAndValue[1]);
+                        break;
+                    case "version":
+                        mAdColonyAppOptions.setAppVersion(optionNameAndValue[1]);
+                        break;
+                    default:
+                        Log.e(TAG, "AdColony client options in wrong format - please check your MoPub dashboard");
+                        return;
+                }
+            } else {
+                Log.e(TAG, "AdColony client options in wrong format - please check your MoPub dashboard");
+                return;
+            }
+        }
+    }
+
+    private boolean isAdColonyConfigured() {
+        return !AdColony.getSDKVersion().isEmpty();
     }
 
     @Override
     public boolean hasVideoAvailable() {
-        return mAd != null && mAd.isReady() && mAd.getAvailableViews() != 0;
+        return mAd != null && !mAd.isExpired();
     }
 
     @Override
     public void showVideo() {
         if (this.hasVideoAvailable()) {
-            boolean withConfirmationDialog = getConfirmationDialogFromSettings();
-            boolean withResultsDialog = getResultsDialogFromSettings();
-            mAd.withConfirmationDialog(withConfirmationDialog).withResultsDialog(withResultsDialog).show();
+            mAd.show();
         } else {
-            MoPubRewardedVideoManager.onRewardedVideoPlaybackError(AdColonyRewardedVideo.class, mZoneId, MoPubErrorCode.VIDEO_PLAYBACK_ERROR);
+            MoPubRewardedVideoManager.onRewardedVideoPlaybackError(
+                    AdColonyRewardedVideo.class,
+                    mZoneId,
+                    MoPubErrorCode.VIDEO_PLAYBACK_ERROR);
         }
     }
 
@@ -191,11 +238,8 @@ public class AdColonyRewardedVideo extends CustomEventRewardedVideo {
         final AdColonyGlobalMediationSettings globalMediationSettings =
                 MoPubRewardedVideoManager.getGlobalMediationSettings(AdColonyGlobalMediationSettings.class);
         if (globalMediationSettings != null) {
-            if (globalMediationSettings.getCustomId() != null) {
-                AdColony.setCustomID(globalMediationSettings.getCustomId());
-            }
-            if (globalMediationSettings.getDeviceId() != null) {
-                AdColony.setDeviceID(globalMediationSettings.getDeviceId());
+            if (globalMediationSettings.getUserId() != null) {
+                mAdColonyAppOptions.setUserID(globalMediationSettings.getUserId());
             }
         }
     }
@@ -216,13 +260,15 @@ public class AdColonyRewardedVideo extends CustomEventRewardedVideo {
         Runnable runnable = new Runnable() {
             @Override
             public void run() {
-                if (mAd.isReady()) {
+                if (isAdAvailable(mZoneId)) {
+                    mAd = sZoneIdToAdMap.get(mZoneId);
                     mIsLoading = false;
                     mScheduledThreadPoolExecutor.shutdownNow();
                     mHandler.post(new Runnable() {
                         @Override
                         public void run() {
-                            if (mAd.getAvailableViews() > 0) {
+                            if (mAd != null && !mAd.isExpired()) {
+                                Log.d(TAG, "AdColony rewarded ad has been successfully loaded.");
                                 MoPubRewardedVideoManager.onRewardedVideoLoadSuccess(
                                         AdColonyRewardedVideo.class,
                                         mZoneId);
@@ -244,71 +290,92 @@ public class AdColonyRewardedVideo extends CustomEventRewardedVideo {
         }
     }
 
-    private static class AdColonyListener implements AdColonyAdListener,
-            AdColonyV4VCListener, CustomEventRewardedVideoListener {
+    private boolean isAdAvailable(String zoneId) {
+        return sZoneIdToAdMap.get(zoneId) != null;
+    }
 
-        @Override
-        public void onAdColonyAdAttemptFinished(final AdColonyAd adColonyAd) {
-            String zoneId = sAdToZoneIdMap.get(adColonyAd);
-            MoPubRewardedVideoManager.onRewardedVideoClosed(AdColonyRewardedVideo.class, zoneId);
-            if (adColonyAd.notShown()) {
-                if (adColonyAd.canceled() || adColonyAd.skipped()) {
-                    MoPubLog.d("User canceled ad playback");
-                    return;
-                }
+    private static class AdColonyListener extends AdColonyInterstitialListener
+            implements AdColonyRewardListener, CustomEventRewardedVideoListener {
+        private static final String TAG = "AdColonyListener";
+        private AdColonyAdOptions mAdOptions;
 
-                MoPubErrorCode reason = MoPubErrorCode.VIDEO_DOWNLOAD_ERROR;
-                if (adColonyAd.noFill()) {
-                    reason = MoPubErrorCode.NETWORK_NO_FILL;
-                }
-
-                MoPubRewardedVideoManager.onRewardedVideoLoadFailure(
-                        AdColonyRewardedVideo.class,
-                        zoneId,
-                        reason);
-            }
+        AdColonyListener(AdColonyAdOptions adOptions) {
+            mAdOptions = adOptions;
         }
 
         @Override
-        public void onAdColonyAdStarted(final com.jirbo.adcolony.AdColonyAd adColonyAd) {
-            MoPubRewardedVideoManager.onRewardedVideoStarted(
-                    AdColonyRewardedVideo.class,
-                    sAdToZoneIdMap.get(adColonyAd));
-        }
-
-        @Override
-        public void onAdColonyV4VCReward(final AdColonyV4VCReward adColonyV4VCReward) {
+        public void onReward(AdColonyReward a) {
             MoPubReward reward;
-            if (adColonyV4VCReward.success()) {
-                reward = MoPubReward.success(adColonyV4VCReward.name(), adColonyV4VCReward.amount());
+            if (a.success()) {
+                Log.d(TAG, "AdColonyReward name: " + a.getRewardName());
+                Log.d(TAG, "AdColonyReward amount: " + a.getRewardAmount());
+                reward = MoPubReward.success(a.getRewardName(), a.getRewardAmount());
             } else {
+                Log.d(TAG, "AdColonyReward failed");
                 reward = MoPubReward.failure();
             }
+
             MoPubRewardedVideoManager.onRewardedVideoCompleted(
                     AdColonyRewardedVideo.class,
-                    null, // Can't deduce the zoneId from this object.
+                    a.getZoneID(),
                     reward);
+        }
+
+        @Override
+        public void onRequestFilled(com.adcolony.sdk.AdColonyInterstitial adColonyInterstitial) {
+            sZoneIdToAdMap.put(adColonyInterstitial.getZoneID(), adColonyInterstitial);
+        }
+
+        @Override
+        public void onRequestNotFilled(AdColonyZone zone) {
+            Log.d(TAG, "AdColony rewarded ad has no fill.");
+            MoPubRewardedVideoManager.onRewardedVideoLoadFailure(
+                    AdColonyRewardedVideo.class,
+                    zone.getZoneID(),
+                    MoPubErrorCode.NETWORK_NO_FILL);
+        }
+
+        @Override
+        public void onClosed(com.adcolony.sdk.AdColonyInterstitial ad) {
+            Log.d(TAG, "AdColony rewarded ad has been dismissed.");
+            MoPubRewardedVideoManager.onRewardedVideoClosed(
+                    AdColonyRewardedVideo.class,
+                    ad.getZoneID());
+        }
+
+        @Override
+        public void onOpened(com.adcolony.sdk.AdColonyInterstitial ad) {
+            Log.d(TAG, "AdColony rewarded ad shown: " + ad.getZoneID());
+            MoPubRewardedVideoManager.onRewardedVideoStarted(
+                    AdColonyRewardedVideo.class,
+                    ad.getZoneID());
+        }
+
+        @Override
+        public void onExpiring(com.adcolony.sdk.AdColonyInterstitial ad) {
+            Log.d(TAG, "AdColony rewarded ad is expiring; requesting new ad");
+            AdColony.requestInterstitial(ad.getZoneID(), ad.getListener(), mAdOptions);
+        }
+
+        @Override
+        public void onClicked(com.adcolony.sdk.AdColonyInterstitial ad) {
+            MoPubRewardedVideoManager.onRewardedVideoClicked(
+                    AdColonyRewardedVideo.class,
+                    ad.getZoneID());
         }
     }
 
     public static final class AdColonyGlobalMediationSettings implements MediationSettings {
+        @Nullable
+        private final String mUserId;
 
-        @Nullable private final String mCustomId;
-        @Nullable private final String mDeviceId;
-
-        public AdColonyGlobalMediationSettings(@Nullable String customId, @Nullable String deviceId) {
-            mCustomId = customId;
-            mDeviceId = deviceId;
+        public AdColonyGlobalMediationSettings(@Nullable String userId) {
+            mUserId = userId;
         }
 
         @Nullable
-        public String getCustomId() {
-            return mCustomId;
-        }
-
-        @Nullable
-        public String getDeviceId() {
-            return mDeviceId;
+        public String getUserId() {
+            return mUserId;
         }
     }
 


### PR DESCRIPTION
**Changes**
		- This updated adapter only supports the AdColony 3.0.5 SDK. Users wanting to use AdColony 2.X will have to use the old adapters.
		- Distribution of our library via AAR is now supported ( https://github.com/AdColony/AdColony-Android-SDK-3/wiki/Project-Setup#via-gradle )
		- API Changes and other information can be found here - ( https://github.com/AdColony/AdColony-Android-SDK-3 ).
		- The minimum API level is now 14.
**Limitations**
		- Only interstitial and rewarded ads are currently supported.		
		- The MIPS architecture is not supported.
		- The "Custom ID" mediation setting used for V4VC validation is now known as "User ID".
		- The "Device ID" mediation setting is now removed.