### PR TITLE
Vungle ad listeners could override each other

### DIFF
--- a/extras/src/com/mopub/mobileads/VungleInterstitial.java
+++ b/extras/src/com/mopub/mobileads/VungleInterstitial.java
@@ -64,7 +64,6 @@ public class VungleInterstitial extends CustomEventInterstitial implements Event
 
         // init clears the event listener.
         mVunglePub.init(context, appId);
-        mVunglePub.setEventListeners(this);
         if (mVunglePub.isAdPlayable()) {
             Log.d("MoPub", "Vungle interstitial ad successfully loaded.");
             mCustomEventInterstitialListener.onInterstitialLoaded();
@@ -77,6 +76,7 @@ public class VungleInterstitial extends CustomEventInterstitial implements Event
     @Override
     protected void showInterstitial() {
         if (mVunglePub.isAdPlayable()) {
+            mVunglePub.setEventListeners(this);
             mVunglePub.playAd();
         } else {
             Log.d("MoPub", "Tried to show a Vungle interstitial ad before it finished loading. Please try again.");
@@ -85,7 +85,7 @@ public class VungleInterstitial extends CustomEventInterstitial implements Event
 
     @Override
     protected void onInvalidate() {
-        mVunglePub.clearEventListeners();
+        mVunglePub.removeEventListeners(this);
     }
 
     private boolean extrasAreValid(Map<String, String> serverExtras) {

--- a/extras/src/com/mopub/mobileads/VungleInterstitial.java
+++ b/extras/src/com/mopub/mobileads/VungleInterstitial.java
@@ -7,11 +7,13 @@ import android.util.Log;
 
 import com.vungle.publisher.EventListener;
 import com.vungle.publisher.VunglePub;
+import com.vungle.publisher.env.WrapperFramework;
+import com.vungle.publisher.inject.Injector;
 
 import java.util.Map;
 
 /*
- * Tested with Vungle SDK 4.0.2
+ * Tested with Vungle SDK 4.0.3
  */
 public class VungleInterstitial extends CustomEventInterstitial implements EventListener {
 
@@ -22,6 +24,9 @@ public class VungleInterstitial extends CustomEventInterstitial implements Event
      */
     public static final String APP_ID_KEY = "appId";
 
+    // Version of the adapter, intended for Vungle internal use.
+    private static final String VERSION = "1.0.0";
+
     private final VunglePub mVunglePub;
     private final Handler mHandler;
     private CustomEventInterstitialListener mCustomEventInterstitialListener;
@@ -29,6 +34,9 @@ public class VungleInterstitial extends CustomEventInterstitial implements Event
     public VungleInterstitial() {
         mHandler = new Handler(Looper.getMainLooper());
         mVunglePub = VunglePub.getInstance();
+        Injector injector = Injector.getInstance();
+        injector.setWrapperFramework(WrapperFramework.mopub);
+        injector.setWrapperFrameworkVersion(VERSION.replace('.', '_'));
     }
 
     @Override

--- a/extras/src/com/mopub/mobileads/VungleRewardedVideo.java
+++ b/extras/src/com/mopub/mobileads/VungleRewardedVideo.java
@@ -102,7 +102,6 @@ public class VungleRewardedVideo extends CustomEventRewardedVideo {
     protected void loadWithSdkInitialized(@NonNull final Activity activity, @NonNull final Map<String, Object> localExtras, @NonNull final Map<String, String> serverExtras) throws Exception {
         String appId = serverExtras.containsKey(APP_ID_KEY) ? serverExtras.get(APP_ID_KEY) : DEFAULT_VUNGLE_APP_ID;
         sVunglePub.init(activity, appId);
-        sVunglePub.setEventListeners(sVungleListener);
         Object adUnitObject = localExtras.get(DataKeys.AD_UNIT_ID_KEY);
         if (adUnitObject instanceof String) {
             mAdUnitId = (String) adUnitObject;
@@ -134,6 +133,7 @@ public class VungleRewardedVideo extends CustomEventRewardedVideo {
         final AdConfig adConfig = new AdConfig();
         adConfig.setIncentivized(true);
         setUpMediationSettingsForRequest(adConfig);
+        sVunglePub.setEventListeners(sVungleListener);
         sVunglePub.playAd(adConfig);
     }
 

--- a/extras/src/com/mopub/mobileads/VungleRewardedVideo.java
+++ b/extras/src/com/mopub/mobileads/VungleRewardedVideo.java
@@ -14,6 +14,8 @@ import com.mopub.common.logging.MoPubLog;
 import com.vungle.publisher.AdConfig;
 import com.vungle.publisher.EventListener;
 import com.vungle.publisher.VunglePub;
+import com.vungle.publisher.env.WrapperFramework;
+import com.vungle.publisher.inject.Injector;
 
 import java.util.Locale;
 import java.util.Map;
@@ -21,7 +23,7 @@ import java.util.Map;
 /**
  * A custom event for showing Vungle rewarded videos.
  *
- * Certified with Vungle 4.0.2
+ * Certified with Vungle 4.0.3
  */
 public class VungleRewardedVideo extends CustomEventRewardedVideo {
 
@@ -32,6 +34,9 @@ public class VungleRewardedVideo extends CustomEventRewardedVideo {
      */
     public static final String APP_ID_KEY = "appId";
     public static final String VUNGLE_AD_NETWORK_CONSTANT = "vngl_id";
+
+    // Version of the adapter, intended for Vungle internal use.
+    private static final String VERSION = "1.0.0";
 
     // This has to be reinitialized every time the CE loads to avoid conflict with the interstitials.
     private static VunglePub sVunglePub;
@@ -82,6 +87,9 @@ public class VungleRewardedVideo extends CustomEventRewardedVideo {
                 @NonNull final Map<String, String> serverExtras) throws Exception {
         synchronized (VungleRewardedVideo.class) {
             if (!sInitialized) {
+                Injector injector = Injector.getInstance();
+                injector.setWrapperFramework(WrapperFramework.mopub);
+                injector.setWrapperFrameworkVersion(VERSION.replace('.', '_'));
                 sVunglePub = VunglePub.getInstance();
                 sInitialized = true;
                 return true;


### PR DESCRIPTION
Vungle adapters when loaded Rewarded and Interstial at the same time would override listener on SDK, resulting in incorrect callbacks. See https://github.com/Vungle/mopub-android-sdk/pull/1 for details. Thanks to @mihailogazda for reporting this issue.