### PR TITLE
Updating mediation adapters from MoPub to support Facebook AN 4.22.0 SDK

### DIFF
--- a/extras/src/com/mopub/mobileads/FacebookBanner.java
+++ b/extras/src/com/mopub/mobileads/FacebookBanner.java
@@ -16,7 +16,7 @@ import com.mopub.common.util.Views;
 import java.util.Map;
 
 /**
- * Tested with Facebook SDK 4.15.0.
+ * Tested with Facebook SDK 4.22.0.
  */
 public class FacebookBanner extends CustomEventBanner implements AdListener {
     public static final String PLACEMENT_ID_KEY = "placement_id";
@@ -100,6 +100,11 @@ public class FacebookBanner extends CustomEventBanner implements AdListener {
     public void onAdClicked(Ad ad) {
         Log.d("MoPub", "Facebook banner ad clicked.");
         mBannerListener.onBannerClicked();
+    }
+
+    @Override
+    public void onLoggingImpression(Ad ad) {
+        Log.d("MoPub", "Facebook banner ad impression.");
     }
 
     private boolean serverExtrasAreValid(final Map<String, String> serverExtras) {

--- a/extras/src/com/mopub/mobileads/FacebookInterstitial.java
+++ b/extras/src/com/mopub/mobileads/FacebookInterstitial.java
@@ -11,7 +11,7 @@ import com.facebook.ads.InterstitialAdListener;
 import java.util.Map;
 
 /**
- * Tested with Facebook SDK 4.15.0.
+ * Tested with Facebook SDK 4.22.0.
  */
 public class FacebookInterstitial extends CustomEventInterstitial implements InterstitialAdListener {
     public static final String PLACEMENT_ID_KEY = "placement_id";
@@ -103,6 +103,11 @@ public class FacebookInterstitial extends CustomEventInterstitial implements Int
     public void onInterstitialDismissed(final Ad ad) {
         Log.d("MoPub", "Facebook interstitial ad dismissed.");
         mInterstitialListener.onInterstitialDismissed();
+    }
+
+    @Override
+    public void onLoggingImpression(Ad ad) {
+        Log.d("MoPub", "Facebook interstitial ad impression.");
     }
 
     private boolean extrasAreValid(final Map<String, String> serverExtras) {

--- a/extras/src/com/mopub/nativeads/FacebookNative.java
+++ b/extras/src/com/mopub/nativeads/FacebookNative.java
@@ -6,7 +6,6 @@ import android.view.View;
 import com.facebook.ads.Ad;
 import com.facebook.ads.AdError;
 import com.facebook.ads.AdListener;
-import com.facebook.ads.ImpressionListener;
 import com.facebook.ads.MediaView;
 import com.facebook.ads.NativeAd;
 import com.facebook.ads.NativeAd.Rating;
@@ -21,7 +20,7 @@ import java.util.Map;
 import static com.mopub.nativeads.NativeImageHelper.preCacheImages;
 
 /**
- * Tested with Facebook SDK 4.15.0. FacebookAdRenderer is also necessary in order to show video ads.
+ * Tested with Facebook SDK 4.22.0. FacebookAdRenderer is also necessary in order to show video ads.
  * Video ads will only be shown if VIDEO_ENABLED is set to true or a server configuration
  * "video_enabled" flag is set to true. The server configuration will override the local
  * configuration.
@@ -126,7 +125,7 @@ public class FacebookNative extends CustomEventNative {
         return (placementId != null && placementId.length() > 0);
     }
 
-    static class FacebookStaticNativeAd extends StaticNativeAd implements AdListener, ImpressionListener {
+    static class FacebookStaticNativeAd extends StaticNativeAd implements AdListener {
         private static final String SOCIAL_CONTEXT_FOR_AD = "socialContextForAd";
 
         private final Context mContext;
@@ -143,7 +142,6 @@ public class FacebookNative extends CustomEventNative {
 
         void loadAd() {
             mNativeAd.setAdListener(this);
-            mNativeAd.setImpressionListener(this);
             mNativeAd.loadAd();
         }
 
@@ -221,7 +219,6 @@ public class FacebookNative extends CustomEventNative {
             notifyAdClicked();
         }
 
-        // ImpressionListener
         @Override
         public void onLoggingImpression(final Ad ad) {
             notifyAdImpressed();
@@ -253,7 +250,7 @@ public class FacebookNative extends CustomEventNative {
     }
 
 
-    static class FacebookVideoEnabledNativeAd extends BaseNativeAd implements AdListener, ImpressionListener {
+    static class FacebookVideoEnabledNativeAd extends BaseNativeAd implements AdListener {
         private static final String SOCIAL_CONTEXT_FOR_AD = "socialContextForAd";
 
         static final double MIN_STAR_RATING = 0;
@@ -278,7 +275,6 @@ public class FacebookNative extends CustomEventNative {
 
         void loadAd() {
             mNativeAd.setAdListener(this);
-            mNativeAd.setImpressionListener(this);
             mNativeAd.loadAd();
         }
 
@@ -407,7 +403,6 @@ public class FacebookNative extends CustomEventNative {
             notifyAdClicked();
         }
 
-        // ImpressionListener
         @Override
         public void onLoggingImpression(final Ad ad) {
             notifyAdImpressed();


### PR DESCRIPTION
On SDK 4.22.0, Audience Network removed teh deprecated ImpressionListener and made the onLoggingImpression method part of AdListener. This updates the mediation code to reflect those changes.