### PR TITLE
Fix fetch UserAgent crash

### DIFF
--- a/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/network/Networking.java
+++ b/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/network/Networking.java
@@ -130,7 +130,15 @@ public class Networking {
                 userAgent = sUserAgent;
                 if (userAgent == null) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                        userAgent = WebSettings.getDefaultUserAgent(context);
+                        // Catch AndroidRuntimeException that could be raised by the
+                        // WebSettings.getDefaultUserAgent() in some custom ROMs (e.g. OPPO,
+                        // HTC, Sony, ASUS, Xiaomi ...). If anything goes wrong with getting a
+                        // user agent, use the system-specific user agent.
+                        try {
+                            userAgent = WebSettings.getDefaultUserAgent(context);
+                        } catch (Exception e) {
+                            userAgent = DEFAULT_USER_AGENT;
+                        }
                     } else if (Looper.myLooper() == Looper.getMainLooper()){
                         // WebViews may only be instantiated on the UI thread. If anything goes
                         // wrong with getting a user agent, use the system-specific user agent.


### PR DESCRIPTION
Catch AndroidRuntimeException that could be raised by the  WebSettings.getDefaultUserAgent() in some custom ROMs (e.g. OPPO, HTC, Sony, ASUS, Xiaomi ...).

Crashlytics Issue Details Screenshot:
![default](https://cloud.githubusercontent.com/assets/5742579/25650235/20bf15e8-300e-11e7-9b1f-03a2f803d1f0.png)

Crash StackTrace:
```
Fatal Exception: android.util.AndroidRuntimeException: java.lang.RuntimeException: Invalid reflection
       at android.webkit.WebViewFactory.getProvider(WebViewFactory.java:146)
       at android.webkit.WebSettings.getDefaultUserAgent(WebSettings.java:1244)
       at com.mopub.network.Networking.getUserAgent(Networking.java:133)
       at com.mopub.network.Networking.getRequestQueue(Networking.java:63)
       at com.mopub.nativeads.MoPubNative.requestNativeAd(MoPubNative.java:192)
       at com.mopub.nativeads.MoPubNative.loadNativeAd(MoPubNative.java:177)
       at com.mopub.nativeads.MoPubNative.makeRequest(MoPubNative.java:152)
       at com.mopub.nativeads.MoPubNative.makeRequest(MoPubNative.java:137)
       ...
```


