### PR TITLE
Updating AdColony adapters for the 3.2.1 SDK

### DIFF
--- a/extras/src/com/mopub/mobileads/AdColonyInterstitial.java
+++ b/extras/src/com/mopub/mobileads/AdColonyInterstitial.java
@@ -3,6 +3,8 @@ package com.mopub.mobileads;
 import android.app.Activity;
 import android.content.Context;
 import android.os.Handler;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.util.Log;
 
 import com.adcolony.sdk.AdColony;
@@ -11,6 +13,7 @@ import com.adcolony.sdk.AdColonyInterstitialListener;
 import com.adcolony.sdk.AdColonyZone;
 import com.mopub.common.util.Json;
 
+import java.util.Arrays;
 import java.util.Map;
 
 public class AdColonyInterstitial extends CustomEventInterstitial {
@@ -39,17 +42,21 @@ public class AdColonyInterstitial extends CustomEventInterstitial {
     private AdColonyInterstitialListener mAdColonyInterstitialListener;
     private final Handler mHandler;
     private com.adcolony.sdk.AdColonyInterstitial mAdColonyInterstitial;
+    private static String[] previousAdColonyAllZoneIds;
 
     public AdColonyInterstitial() {
         mHandler = new Handler();
     }
 
     @Override
-    protected void loadInterstitial(Context context,
-                                    CustomEventInterstitialListener customEventInterstitialListener,
-                                    Map<String, Object> localExtras,
-                                    Map<String, String> serverExtras) {
-        if (!(context instanceof Activity)) {
+    protected void loadInterstitial(@NonNull Context context,
+                                    @NonNull CustomEventInterstitialListener customEventInterstitialListener,
+                                    @Nullable Map<String, Object> localExtras,
+                                    @NonNull Map<String, String> serverExtras) {
+        if (context == null
+                || !(context instanceof Activity)
+                || customEventInterstitialListener == null
+                || serverExtras == null) {
             customEventInterstitialListener.onInterstitialFailed(MoPubErrorCode.ADAPTER_CONFIGURATION_ERROR);
             return;
         }
@@ -67,10 +74,15 @@ public class AdColonyInterstitial extends CustomEventInterstitial {
             allZoneIds = extractAllZoneIds(serverExtras);
             zoneId = serverExtras.get(ZONE_ID_KEY);
         }
-
+        AdColonyAppOptions adColonyAppOptions = AdColonyAppOptions.getMoPubAppOptions(clientOptions);
         mAdColonyInterstitialListener = getAdColonyInterstitialListener();
         if (!isAdColonyConfigured()) {
-            AdColony.configure((Activity) context, getAppOptions(clientOptions), appId, allZoneIds);
+            AdColony.configure((Activity) context, adColonyAppOptions, appId, allZoneIds);
+        } else if ((shouldReconfigure(previousAdColonyAllZoneIds, allZoneIds))) {
+            // Need to check the zone IDs sent from the MoPub portal and reconfigure if they are
+            // different than the zones we initially called AdColony.configure() with
+            AdColony.configure((Activity) context, adColonyAppOptions, appId, allZoneIds);
+            previousAdColonyAllZoneIds = allZoneIds;
         }
 
         AdColony.requestInterstitial(zoneId, mAdColonyInterstitialListener);
@@ -101,35 +113,6 @@ public class AdColonyInterstitial extends CustomEventInterstitial {
         }
     }
 
-    private AdColonyAppOptions getAppOptions(String clientOptions) {
-        if (clientOptions == null || clientOptions.isEmpty()) {
-            return null;
-        }
-        AdColonyAppOptions adColonyAppOptions = new AdColonyAppOptions();
-        String[] allOptions = clientOptions.split(",");
-        for (String option : allOptions) {
-            String optionNameAndValue[] = option.split(":");
-            if (optionNameAndValue.length == 2) {
-                switch (optionNameAndValue[0]) {
-                    case "store":
-                        adColonyAppOptions.setOriginStore(optionNameAndValue[1]);
-                        break;
-                    case "version":
-                        adColonyAppOptions.setAppVersion(optionNameAndValue[1]);
-                        break;
-                    default:
-                        Log.e(TAG, "AdColony client options in wrong format - please check your MoPub dashboard");
-                        return null;
-                }
-            } else {
-                Log.e(TAG, "AdColony client options in wrong format - please check your MoPub dashboard");
-                return null;
-            }
-        }
-
-        return adColonyAppOptions;
-    }
-
     private boolean isAdColonyConfigured() {
         return !AdColony.getSDKVersion().isEmpty();
     }
@@ -140,7 +123,7 @@ public class AdColonyInterstitial extends CustomEventInterstitial {
         } else {
             return new AdColonyInterstitialListener() {
                 @Override
-                public void onRequestFilled(com.adcolony.sdk.AdColonyInterstitial adColonyInterstitial) {
+                public void onRequestFilled(@NonNull com.adcolony.sdk.AdColonyInterstitial adColonyInterstitial) {
                     mAdColonyInterstitial = adColonyInterstitial;
                     Log.d(TAG, "AdColony interstitial ad has been successfully loaded.");
                     mHandler.post(new Runnable() {
@@ -152,7 +135,7 @@ public class AdColonyInterstitial extends CustomEventInterstitial {
                 }
 
                 @Override
-                public void onRequestNotFilled(AdColonyZone zone) {
+                public void onRequestNotFilled(@NonNull AdColonyZone zone) {
                     Log.d(TAG, "AdColony interstitial ad has no fill.");
                     mHandler.post(new Runnable() {
                         @Override
@@ -163,7 +146,7 @@ public class AdColonyInterstitial extends CustomEventInterstitial {
                 }
 
                 @Override
-                public void onClosed(com.adcolony.sdk.AdColonyInterstitial ad) {
+                public void onClosed(@NonNull com.adcolony.sdk.AdColonyInterstitial ad) {
                     Log.d(TAG, "AdColony interstitial ad has been dismissed.");
                     mHandler.post(new Runnable() {
                         @Override
@@ -174,7 +157,7 @@ public class AdColonyInterstitial extends CustomEventInterstitial {
                 }
 
                 @Override
-                public void onOpened(com.adcolony.sdk.AdColonyInterstitial ad) {
+                public void onOpened(@NonNull com.adcolony.sdk.AdColonyInterstitial ad) {
                     Log.d(TAG, "AdColony interstitial ad shown: " + ad.getZoneID());
                     mHandler.post(new Runnable() {
                         @Override
@@ -185,13 +168,13 @@ public class AdColonyInterstitial extends CustomEventInterstitial {
                 }
 
                 @Override
-                public void onExpiring(com.adcolony.sdk.AdColonyInterstitial ad) {
+                public void onExpiring(@NonNull com.adcolony.sdk.AdColonyInterstitial ad) {
                     Log.d(TAG, "AdColony interstitial ad is expiring; requesting new ad");
                     AdColony.requestInterstitial(ad.getZoneID(), mAdColonyInterstitialListener);
                 }
 
                 @Override
-                public void onLeftApplication(com.adcolony.sdk.AdColonyInterstitial ad) {
+                public void onLeftApplication(@NonNull com.adcolony.sdk.AdColonyInterstitial ad) {
                     mHandler.post(new Runnable() {
                         @Override
                         public void run() {
@@ -201,7 +184,7 @@ public class AdColonyInterstitial extends CustomEventInterstitial {
                 }
 
                 @Override
-                public void onClicked(com.adcolony.sdk.AdColonyInterstitial ad) {
+                public void onClicked(@NonNull com.adcolony.sdk.AdColonyInterstitial ad) {
                     mCustomEventInterstitialListener.onInterstitialClicked();
                 }
             };
@@ -209,10 +192,28 @@ public class AdColonyInterstitial extends CustomEventInterstitial {
     }
 
     private boolean extrasAreValid(Map<String, String> extras) {
-        return extras.containsKey(CLIENT_OPTIONS_KEY)
+        return extras != null
+                && extras.containsKey(CLIENT_OPTIONS_KEY)
                 && extras.containsKey(APP_ID_KEY)
                 && extras.containsKey(ALL_ZONE_IDS_KEY)
                 && extras.containsKey(ZONE_ID_KEY);
+    }
+
+    private static boolean shouldReconfigure(String[] previousZones, String[] newZones) {
+        // If AdColony is configured already, but previousZones is null, then that means AdColony
+        // was configured with the AdColonyRewardedVideo adapter so attempt to configure with
+        // the ids in newZones. They will be ignored within the AdColony SDK if the zones are
+        // the same as the zones that the other adapter called AdColony.configure() with.
+        if (previousZones == null) {
+            return true;
+        } else if (newZones == null) {
+            return false;
+        } else if (previousZones.length != newZones.length) {
+            return true;
+        }
+        Arrays.sort(previousZones);
+        Arrays.sort(newZones);
+        return !Arrays.equals(previousZones, newZones);
     }
 
     private String[] extractAllZoneIds(Map<String, String> serverExtras) {
@@ -224,11 +225,5 @@ public class AdColonyInterstitial extends CustomEventInterstitial {
         }
 
         return result;
-    }
-
-    @Deprecated
-    // For testing
-    public static String getAdUnitId(MoPubInterstitial interstitial) {
-        return interstitial.getMoPubInterstitialView().getAdUnitId();
     }
 }

--- a/extras/src/com/mopub/mobileads/AdColonyRewardedVideo.java
+++ b/extras/src/com/mopub/mobileads/AdColonyRewardedVideo.java
@@ -22,6 +22,7 @@ import com.mopub.common.MediationSettings;
 import com.mopub.common.MoPubReward;
 import com.mopub.common.util.Json;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -54,6 +55,7 @@ public class AdColonyRewardedVideo extends CustomEventRewardedVideo {
 
     private static boolean sInitialized = false;
     private static LifecycleListener sLifecycleListener = new BaseLifecycleListener();
+    private static String[] previousAdColonyAllZoneIds;
 
     AdColonyInterstitial mAd;
     private String mZoneId;
@@ -127,9 +129,9 @@ public class AdColonyRewardedVideo extends CustomEventRewardedVideo {
             }
 
             setUpGlobalSettings();
-            setAppOptions(adColonyClientOptions);
-
+            mAdColonyAppOptions = AdColonyAppOptions.getMoPubAppOptions(adColonyClientOptions);
             if (!isAdColonyConfigured()) {
+                previousAdColonyAllZoneIds = adColonyAllZoneIds;
                 AdColony.configure(launcherActivity, mAdColonyAppOptions, adColonyAppId, adColonyAllZoneIds);
             }
 
@@ -142,11 +144,22 @@ public class AdColonyRewardedVideo extends CustomEventRewardedVideo {
     protected void loadWithSdkInitialized(@NonNull final Activity activity,
                                           @NonNull final Map<String, Object> localExtras,
                                           @NonNull final Map<String, String> serverExtras) throws Exception {
-
         mZoneId = DEFAULT_ZONE_ID;
         if (extrasAreValid(serverExtras)) {
             mZoneId = serverExtras.get(ZONE_ID_KEY);
+            String adColonyClientOptions = serverExtras.get(CLIENT_OPTIONS_KEY);
+            String adColonyAppId = serverExtras.get(APP_ID_KEY);
+            String[] adColonyAllZoneIds = extractAllZoneIds(serverExtras);
+
+            // Need to check the zone IDs sent from the MoPub portal and reconfigure if they are
+            // different than the zones we initially called AdColony.configure() with
+            if (shouldReconfigure(previousAdColonyAllZoneIds, adColonyAllZoneIds)) {
+                mAdColonyAppOptions = AdColonyAppOptions.getMoPubAppOptions(adColonyClientOptions);
+                AdColony.configure(activity, mAdColonyAppOptions, adColonyAppId, adColonyAllZoneIds);
+                previousAdColonyAllZoneIds = adColonyAllZoneIds;
+            }
         }
+
         Object adUnitObject = localExtras.get(DataKeys.AD_UNIT_ID_KEY);
         if (adUnitObject != null && adUnitObject instanceof String) {
             mAdUnitId = (String) adUnitObject;
@@ -160,38 +173,26 @@ public class AdColonyRewardedVideo extends CustomEventRewardedVideo {
         scheduleOnVideoReady();
     }
 
+    private static boolean shouldReconfigure(String[] previousZones, String[] newZones) {
+        // If AdColony is configured already, but previousZones is null, then that means AdColony
+        // was configured with the AdColonyInterstitial adapter so attempt to configure with
+        // the ids in newZones. They will be ignored within the AdColony SDK if the zones are
+        // the same as the zones that the other adapter called AdColony.configure() with.
+        if (previousZones == null) {
+            return true;
+        } else if (newZones == null) {
+            return false;
+        } else if (previousZones.length != newZones.length) {
+            return true;
+        }
+        Arrays.sort(previousZones);
+        Arrays.sort(newZones);
+        return !Arrays.equals(previousZones, newZones);
+    }
+
     private void setUpAdOptions() {
         mAdColonyAdOptions.enableConfirmationDialog(getConfirmationDialogFromSettings());
         mAdColonyAdOptions.enableResultsDialog(getResultsDialogFromSettings());
-    }
-
-    private void setAppOptions(String clientOptions) {
-        if(android.text.TextUtils.isEmpty(clientOptions)) {
-            Log.d(TAG, "AdColony client options are not configured on the MoPub dashboard");
-            return;
-        }
-
-        String[] allOptions = clientOptions.split(",");
-        for (String option : allOptions) {
-            String optionNameAndValue[] = option.split(":");
-            if (optionNameAndValue.length == 2) {
-                switch (optionNameAndValue[0]) {
-                    case "store":
-                        mAdColonyAppOptions.setOriginStore(optionNameAndValue[1]);
-                        break;
-                    case "version":
-                        mAdColonyAppOptions.setAppVersion(optionNameAndValue[1]);
-                        break;
-                    default:
-                        Log.e(TAG, "AdColony client options in wrong format - please check your MoPub dashboard");
-                        return;
-                }
-            } else {
-                Log.e(TAG, "AdColony client options is not recognized - please check your MoPub " +
-                        "dashboard");
-                return;
-            }
-        }
     }
 
     private boolean isAdColonyConfigured() {
@@ -216,7 +217,8 @@ public class AdColonyRewardedVideo extends CustomEventRewardedVideo {
     }
 
     private boolean extrasAreValid(Map<String, String> extras) {
-        return extras.containsKey(CLIENT_OPTIONS_KEY)
+        return extras != null
+                && extras.containsKey(CLIENT_OPTIONS_KEY)
                 && extras.containsKey(APP_ID_KEY)
                 && extras.containsKey(ALL_ZONE_IDS_KEY)
                 && extras.containsKey(ZONE_ID_KEY);
@@ -303,7 +305,7 @@ public class AdColonyRewardedVideo extends CustomEventRewardedVideo {
         }
 
         @Override
-        public void onReward(AdColonyReward a) {
+        public void onReward(@NonNull AdColonyReward a) {
             MoPubReward reward;
             if (a.success()) {
                 Log.d(TAG, "AdColonyReward name: " + a.getRewardName());
@@ -321,12 +323,12 @@ public class AdColonyRewardedVideo extends CustomEventRewardedVideo {
         }
 
         @Override
-        public void onRequestFilled(com.adcolony.sdk.AdColonyInterstitial adColonyInterstitial) {
+        public void onRequestFilled(@NonNull com.adcolony.sdk.AdColonyInterstitial adColonyInterstitial) {
             sZoneIdToAdMap.put(adColonyInterstitial.getZoneID(), adColonyInterstitial);
         }
 
         @Override
-        public void onRequestNotFilled(AdColonyZone zone) {
+        public void onRequestNotFilled(@NonNull AdColonyZone zone) {
             Log.d(TAG, "AdColony rewarded ad has no fill.");
             MoPubRewardedVideoManager.onRewardedVideoLoadFailure(
                     AdColonyRewardedVideo.class,
@@ -335,7 +337,7 @@ public class AdColonyRewardedVideo extends CustomEventRewardedVideo {
         }
 
         @Override
-        public void onClosed(com.adcolony.sdk.AdColonyInterstitial ad) {
+        public void onClosed(@NonNull com.adcolony.sdk.AdColonyInterstitial ad) {
             Log.d(TAG, "AdColony rewarded ad has been dismissed.");
             MoPubRewardedVideoManager.onRewardedVideoClosed(
                     AdColonyRewardedVideo.class,
@@ -343,7 +345,7 @@ public class AdColonyRewardedVideo extends CustomEventRewardedVideo {
         }
 
         @Override
-        public void onOpened(com.adcolony.sdk.AdColonyInterstitial ad) {
+        public void onOpened(@NonNull com.adcolony.sdk.AdColonyInterstitial ad) {
             Log.d(TAG, "AdColony rewarded ad shown: " + ad.getZoneID());
             MoPubRewardedVideoManager.onRewardedVideoStarted(
                     AdColonyRewardedVideo.class,
@@ -351,13 +353,13 @@ public class AdColonyRewardedVideo extends CustomEventRewardedVideo {
         }
 
         @Override
-        public void onExpiring(com.adcolony.sdk.AdColonyInterstitial ad) {
+        public void onExpiring(@NonNull com.adcolony.sdk.AdColonyInterstitial ad) {
             Log.d(TAG, "AdColony rewarded ad is expiring; requesting new ad");
             AdColony.requestInterstitial(ad.getZoneID(), ad.getListener(), mAdOptions);
         }
 
         @Override
-        public void onClicked(com.adcolony.sdk.AdColonyInterstitial ad) {
+        public void onClicked(@NonNull com.adcolony.sdk.AdColonyInterstitial ad) {
             MoPubRewardedVideoManager.onRewardedVideoClicked(
                     AdColonyRewardedVideo.class,
                     ad.getZoneID());


### PR DESCRIPTION
**Changes**
- This updated adapter only supports the AdColony 3.2.1 SDK and future releases.
- Information about updating from previous versions can be found here: https://github.com/AdColony/AdColony-Android-SDK-3#upgrade
- When changing AdColony zone IDs on the MoPub portal, the SDK will now reconfigure.