### PR TITLE
MoPubInterstitial changed to be initialized with context instead of an activity

### DIFF
--- a/mopub-sdk/mopub-sdk-interstitial/src/main/java/com/mopub/mobileads/CustomEventInterstitialAdapter.java
+++ b/mopub-sdk/mopub-sdk-interstitial/src/main/java/com/mopub/mobileads/CustomEventInterstitialAdapter.java
@@ -44,7 +44,7 @@ public class CustomEventInterstitialAdapter implements CustomEventInterstitialLi
         mHandler = new Handler();
         mMoPubInterstitial = moPubInterstitial;
         mBroadcastIdentifier = broadcastIdentifier;
-        mContext = mMoPubInterstitial.getActivity();
+        mContext = mMoPubInterstitial.getContext();
         mTimeout = new Runnable() {
             @Override
             public void run() {

--- a/mopub-sdk/mopub-sdk-interstitial/src/main/java/com/mopub/mobileads/MoPubInterstitial.java
+++ b/mopub-sdk/mopub-sdk-interstitial/src/main/java/com/mopub/mobileads/MoPubInterstitial.java
@@ -1,6 +1,5 @@
 package com.mopub.mobileads;
 
-import android.app.Activity;
 import android.content.Context;
 import android.location.Location;
 import android.os.Handler;
@@ -57,7 +56,7 @@ public class MoPubInterstitial implements CustomEventInterstitialAdapter.CustomE
     @NonNull private MoPubInterstitialView mInterstitialView;
     @Nullable private CustomEventInterstitialAdapter mCustomEventInterstitialAdapter;
     @Nullable private InterstitialAdListener mInterstitialAdListener;
-    @NonNull private Activity mActivity;
+    @NonNull private Context mContext;
     @NonNull private Handler mHandler;
     @NonNull private final Runnable mAdExpiration;
     @NonNull private volatile InterstitialState mCurrentInterstitialState;
@@ -70,10 +69,10 @@ public class MoPubInterstitial implements CustomEventInterstitialAdapter.CustomE
         void onInterstitialDismissed(MoPubInterstitial interstitial);
     }
 
-    public MoPubInterstitial(@NonNull final Activity activity, @NonNull final String adUnitId) {
-        mActivity = activity;
+    public MoPubInterstitial(@NonNull final Context context, @NonNull final String adUnitId) {
+        mContext = context.getApplicationContext();
 
-        mInterstitialView = new MoPubInterstitialView(mActivity);
+        mInterstitialView = new MoPubInterstitialView(mContext);
         mInterstitialView.setAdUnitId(adUnitId);
 
         mCurrentInterstitialState = IDLE;
@@ -310,8 +309,8 @@ public class MoPubInterstitial implements CustomEventInterstitialAdapter.CustomE
     }
 
     @NonNull
-    public Activity getActivity() {
-        return mActivity;
+    public Context getContext() {
+        return mContext;
     }
 
     @Nullable


### PR DESCRIPTION
There is no need to get an activity in MoPubInterstitial when MoPubInterstitialView wants a context. And also the activity reference in MoPubInterstitial may cause an activity leak 