### PR TITLE
Adding mediation service information for Facebook adapters

### DIFF
--- a/extras/src/com/mopub/mobileads/FacebookBanner.java
+++ b/extras/src/com/mopub/mobileads/FacebookBanner.java
@@ -8,9 +8,11 @@ import android.util.Log;
 import com.facebook.ads.Ad;
 import com.facebook.ads.AdError;
 import com.facebook.ads.AdListener;
+import com.facebook.ads.AdSettings;
 import com.facebook.ads.AdSize;
 import com.facebook.ads.AdView;
 import com.mopub.common.DataKeys;
+import com.mopub.common.MoPub;
 import com.mopub.common.util.Views;
 
 import java.util.Map;
@@ -58,6 +60,8 @@ public class FacebookBanner extends CustomEventBanner implements AdListener {
             mBannerListener.onBannerFailed(MoPubErrorCode.ADAPTER_CONFIGURATION_ERROR);
             return;
         }
+
+        AdSettings.setMediationService("MOPUB_" + MoPub.SDK_VERSION);
 
         mFacebookBanner = new AdView(context, placementId, adSize);
         mFacebookBanner.setAdListener(this);

--- a/extras/src/com/mopub/mobileads/FacebookInterstitial.java
+++ b/extras/src/com/mopub/mobileads/FacebookInterstitial.java
@@ -5,8 +5,10 @@ import android.util.Log;
 
 import com.facebook.ads.Ad;
 import com.facebook.ads.AdError;
+import com.facebook.ads.AdSettings;
 import com.facebook.ads.InterstitialAd;
 import com.facebook.ads.InterstitialAdListener;
+import com.mopub.common.MoPub;
 
 import java.util.Map;
 
@@ -28,6 +30,7 @@ public class FacebookInterstitial extends CustomEventInterstitial implements Int
             final CustomEventInterstitialListener customEventInterstitialListener,
             final Map<String, Object> localExtras,
             final Map<String, String> serverExtras) {
+        Log.e("MoPub", "Loading Facebook interstitial");
         mInterstitialListener = customEventInterstitialListener;
 
         final String placementId;
@@ -37,6 +40,8 @@ public class FacebookInterstitial extends CustomEventInterstitial implements Int
             mInterstitialListener.onInterstitialFailed(MoPubErrorCode.ADAPTER_CONFIGURATION_ERROR);
             return;
         }
+
+        AdSettings.setMediationService("MOPUB_" + MoPub.SDK_VERSION);
 
         mFacebookInterstitial = new InterstitialAd(context, placementId);
         mFacebookInterstitial.setAdListener(this);

--- a/extras/src/com/mopub/mobileads/FacebookRewardedVideo.java
+++ b/extras/src/com/mopub/mobileads/FacebookRewardedVideo.java
@@ -7,10 +7,12 @@ import android.text.TextUtils;
 import android.util.Log;
 
 import com.facebook.ads.AdError;
+import com.facebook.ads.AdSettings;
 import com.facebook.ads.RewardedVideoAd;
 import com.facebook.ads.RewardedVideoAdListener;
 import com.mopub.common.LifecycleListener;
 import com.facebook.ads.Ad;
+import com.mopub.common.MoPub;
 import com.mopub.common.MoPubReward;
 
 import java.util.Map;
@@ -70,6 +72,7 @@ public class FacebookRewardedVideo extends CustomEventRewardedVideo implements R
 
         if (mRewardedVideoAd != null) {
             Log.d(TAG, "Sending Facebook an ad request.");
+            AdSettings.setMediationService("MOPUB_" + MoPub.SDK_VERSION);
             mRewardedVideoAd.loadAd();
         }
     }

--- a/extras/src/com/mopub/nativeads/FacebookNative.java
+++ b/extras/src/com/mopub/nativeads/FacebookNative.java
@@ -7,9 +7,11 @@ import android.view.ViewGroup;
 import com.facebook.ads.Ad;
 import com.facebook.ads.AdError;
 import com.facebook.ads.AdListener;
+import com.facebook.ads.AdSettings;
 import com.facebook.ads.MediaView;
 import com.facebook.ads.NativeAd;
 import com.facebook.ads.NativeAd.Rating;
+import com.mopub.common.MoPub;
 import com.mopub.common.Preconditions;
 import com.mopub.common.logging.MoPubLog;
 
@@ -182,6 +184,7 @@ public class FacebookNative extends CustomEventNative {
         }
 
         void loadAd() {
+            AdSettings.setMediationService("MOPUB_" + MoPub.SDK_VERSION);
             mNativeAd.setAdListener(this);
             mNativeAd.loadAd();
         }
@@ -315,6 +318,7 @@ public class FacebookNative extends CustomEventNative {
         }
 
         void loadAd() {
+            AdSettings.setMediationService("MOPUB_" + MoPub.SDK_VERSION);
             mNativeAd.setAdListener(this);
             mNativeAd.loadAd();
         }


### PR DESCRIPTION
Adding mediation service information in Facebook adapters, similar to [this PR for the iOS SDK](https://github.com/mopub/mopub-ios-sdk/pull/236)