### PR TITLE
Fix mraid banner and mrect failover

### DIFF
--- a/mopub-sdk/mopub-sdk-banner/src/main/java/com/mopub/mobileads/CustomEventBanner.java
+++ b/mopub-sdk/mopub-sdk-banner/src/main/java/com/mopub/mobileads/CustomEventBanner.java
@@ -50,7 +50,7 @@ public abstract class CustomEventBanner {
          * needs to display the provided View. Failure to do so will disrupt the mediation waterfall
          * and cause future ad requests to stall.
          */
-        void onBannerLoaded(View bannerView);
+        void onBannerLoaded(View bannerView, boolean failedToLoadOnce);
         
         /*
          * Your custom event subclass must call this method when it fails to load an ad.

--- a/mopub-sdk/mopub-sdk-banner/src/main/java/com/mopub/mobileads/CustomEventBannerAdapter.java
+++ b/mopub-sdk/mopub-sdk-banner/src/main/java/com/mopub/mobileads/CustomEventBannerAdapter.java
@@ -209,7 +209,7 @@ public class CustomEventBannerAdapter implements CustomEventBannerListener {
      * CustomEventBanner.Listener implementation
      */
     @Override
-    public void onBannerLoaded(View bannerView) {
+    public void onBannerLoaded(View bannerView, boolean failedToLoadOnce) {
         if (isInvalidated()) {
             return;
         }
@@ -245,7 +245,7 @@ public class CustomEventBannerAdapter implements CustomEventBannerListener {
 
             // Old behavior
             if (!mIsVisibilityImpressionTrackingEnabled) {
-                if (!(bannerView instanceof HtmlBannerWebView)) {
+                if (!(bannerView instanceof HtmlBannerWebView) && !failedToLoadOnce) {
                     mMoPubView.trackNativeImpression();
                 }
             }

--- a/mopub-sdk/mopub-sdk-banner/src/main/java/com/mopub/mraid/MraidBanner.java
+++ b/mopub-sdk/mopub-sdk-banner/src/main/java/com/mopub/mraid/MraidBanner.java
@@ -63,15 +63,18 @@ class MraidBanner extends CustomEventBanner {
 
         mMraidController.setDebugListener(mDebugListener);
         mMraidController.setMraidListener(new MraidListener() {
+            public boolean failedToLoadOnce = false;
+
             @Override
             public void onLoaded(View view) {
                 // Honoring the server dimensions forces the WebView to be the size of the banner
                 AdViewController.setShouldHonorServerDimensions(view);
-                mBannerListener.onBannerLoaded(view);
+                mBannerListener.onBannerLoaded(view, this.failedToLoadOnce);
             }
 
             @Override
             public void onFailedToLoad() {
+                failedToLoadOnce = true;
                 mBannerListener.onBannerFailed(MRAID_LOAD_ERROR);
             }
 


### PR DESCRIPTION
[https://developers.mopub.com/docs/mediation/custom-networks/](SDK Documentation) claims that it has the following support:
Android
`MRAID banner: failover works [as of Android SDK = 3.5] `

Unfortunately this seem not to be the case since SDK confirms impression after Custom Ad tag fails over in synch way, as described in documentation.
I might be wrong with this, and in that case I would appreciate if you could point me how can I have mraid banner to failover without SDK to confirm impression.