### PR TITLE
Handle MissingWebViewPackageException w/o crashing for GDPR consent

### DIFF
--- a/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/common/privacy/ConsentDialogLayout.java
+++ b/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/common/privacy/ConsentDialogLayout.java
@@ -84,7 +84,11 @@ class ConsentDialogLayout extends CloseableLayout {
 
     @SuppressLint("SetJavaScriptEnabled")
     private WebView initWebView() {
-        WebView webView = new WebView(getContext());
+        try {
+            WebView webView = new WebView(getContext());
+        } catch (RuntimeException re) {
+            return null;
+        }
         webView.setVerticalScrollBarEnabled(false);
         webView.setHorizontalScrollBarEnabled(false);
 


### PR DESCRIPTION
Gracefully fail when the WebView package is missing, rather than crashing the app because we can't display the GDPR consent dialog.
We should react to a null return of WebView as content is not obtained (or personalInfoData.setConsentStatus(ConsentStatus.UNKNOWN)?) and continue executing rather than crashing the whole application.