### PR TITLE
Do not store context because of Activity leaks

### DIFF
--- a/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/mobileads/BaseBroadcastReceiver.java
+++ b/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/mobileads/BaseBroadcastReceiver.java
@@ -36,7 +36,7 @@ public abstract class BaseBroadcastReceiver extends BroadcastReceiver {
     public abstract IntentFilter getIntentFilter();
 
     public void register(final @NonNull BroadcastReceiver broadcastReceiver, Context context) {
-        mContext = context;
+        mContext = context.getApplicationContext();
         LocalBroadcastManager.getInstance(mContext).registerReceiver(broadcastReceiver,
                 getIntentFilter());
     }


### PR DESCRIPTION
There is no point to store original context, because it can lead to activity leaks - in LocalBroadcastManager.getInstance(context) a context.getApplicationContext() method is used - so original context is not used anywhere.