### PR TITLE
Catch IOException when closing HttpUrlConnection in UrlResolutionTask

### DIFF
--- a/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/common/UrlResolutionTask.java
+++ b/mopub-sdk/mopub-sdk-base/src/main/java/com/mopub/common/UrlResolutionTask.java
@@ -100,7 +100,12 @@ public class UrlResolutionTask extends AsyncTask<String, Void, String> {
             return resolveRedirectLocation(urlString, httpUrlConnection);
         } finally {
             if (httpUrlConnection != null) {
-                final InputStream is = httpUrlConnection.getInputStream();
+                InputStream is = null;
+                try {
+                    is = httpUrlConnection.getInputStream();
+                } catch (IOException e) {
+                    MoPubLog.log(CUSTOM, "IOException when getting an inputStream on httpUrlConnection. Ignoring.");
+                }
                 if (is != null) {
                     try {
                         is.close();


### PR DESCRIPTION
If an IOException is thrown, the resolution of the URL fails.